### PR TITLE
Fix exported status of role structures

### DIFF
--- a/client.go
+++ b/client.go
@@ -254,7 +254,7 @@ func (c *client) deleteApp(ctx context.Context, appObjectID string) error {
 }
 
 // assignRoles assigns Azure roles to a service principal.
-func (c *client) assignRoles(ctx context.Context, sp *graphrbac.ServicePrincipal, roles []*azureRole) ([]string, error) {
+func (c *client) assignRoles(ctx context.Context, sp *graphrbac.ServicePrincipal, roles []*AzureRole) ([]string, error) {
 	var ids []string
 
 	for _, role := range roles {

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -186,7 +186,7 @@ func TestRoleCreate(t *testing.T) {
 
 		resp, err = testRoleRead(t, b, s, name)
 		nilErr(t, err)
-		roles := resp.Data["azure_roles"].([]*azureRole)
+		roles := resp.Data["azure_roles"].([]*AzureRole)
 		equal(t, "Owner", roles[0].RoleName)
 		equal(t, "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner", roles[0].RoleID)
 		equal(t, "Contributor", roles[1].RoleName)

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -91,7 +91,7 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 }
 
 // createSPSecret generates a new App/Service Principal.
-func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, roleName string, role *Role) (*logical.Response, error) {
+func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*logical.Response, error) {
 	// Create the App, which is the top level object to be tracked in the secret
 	// and deleted upon revocation. If any subsequent step fails, the App is deleted.
 	app, err := c.createApp(ctx)
@@ -129,7 +129,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 }
 
 // createStaticSPSecret adds a new password to the App associated with the role.
-func (b *azureSecretBackend) createStaticSPSecret(ctx context.Context, c *client, roleName string, role *Role) (*logical.Response, error) {
+func (b *azureSecretBackend) createStaticSPSecret(ctx context.Context, c *client, roleName string, role *roleEntry) (*logical.Response, error) {
 	lock := locksutil.LockForKey(b.appLocks, role.ApplicationObjectID)
 	lock.Lock()
 	defer lock.Unlock()

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -24,13 +24,13 @@ const (
 )
 
 var testRole = map[string]interface{}{
-	"azure_roles": encodeJSON([]azureRole{
-		azureRole{
+	"azure_roles": encodeJSON([]AzureRole{
+		AzureRole{
 			RoleName: "Owner",
 			RoleID:   "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
 			Scope:    "/subscriptions/ce7d1612-67c1-4dc6-8d81-4e0a432e696b",
 		},
-		azureRole{
+		AzureRole{
 			RoleName: "Contributor",
 			RoleID:   "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
 			Scope:    "/subscriptions/ce7d1612-67c1-4dc6-8d81-4e0a432e696b",


### PR DESCRIPTION
The visibility of "Role" and "azureRole" seems flipped. "Role" is a
storage structure for internal use that shouldn't be exported, whereas
"azureRole" directly maps to the data from the API requests and probably
should be available outside of the package.

Fixes #28