### PR TITLE
Add Dynamic Service Principal to AAD Groups

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -133,7 +133,9 @@ func (m *mockProvider) GetRoleByID(ctx context.Context, roleID string) (result a
 }
 
 func (m *mockProvider) CreateServicePrincipal(ctx context.Context, parameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error) {
-	return graphrbac.ServicePrincipal{}, nil
+	return graphrbac.ServicePrincipal{
+		ObjectID: to.StringPtr(generateUUID()),
+	}, nil
 }
 
 func (m *mockProvider) CreateApplication(ctx context.Context, parameters graphrbac.ApplicationCreateParameters) (graphrbac.Application, error) {
@@ -205,4 +207,58 @@ func (m *mockProvider) CreateRoleAssignment(ctx context.Context, scope string, r
 
 func (m *mockProvider) DeleteRoleAssignmentByID(ctx context.Context, roleID string) (result authorization.RoleAssignment, err error) {
 	return authorization.RoleAssignment{}, nil
+}
+
+// AddGroupMember adds a member to a AAD Group.
+func (m *mockProvider) AddGroupMember(ctx context.Context, groupObjectID string, parameters graphrbac.GroupAddMemberParameters) (result autorest.Response, err error) {
+	return autorest.Response{}, nil
+}
+
+// RemoveGroupMember removes a member from a AAD Group.
+func (m *mockProvider) RemoveGroupMember(ctx context.Context, groupObjectID, memberObjectID string) (result autorest.Response, err error) {
+	return autorest.Response{}, nil
+}
+
+// GetGroup gets group information from the directory.
+func (m *mockProvider) GetGroup(ctx context.Context, objectID string) (result graphrbac.ADGroup, err error) {
+	g := graphrbac.ADGroup{
+		ObjectID: to.StringPtr(objectID),
+	}
+	s := strings.Split(objectID, "FAKE_GROUP-")
+	if len(s) > 1 {
+		g.DisplayName = to.StringPtr(s[1])
+	}
+
+	return g, nil
+}
+
+// ListGroups gets list of groups for the current tenant.
+func (m *mockProvider) ListGroups(ctx context.Context, filter string) (result []graphrbac.ADGroup, err error) {
+	reGroupName := regexp.MustCompile("displayName eq '(.*)'")
+
+	match := reGroupName.FindAllStringSubmatch(filter, -1)
+	if len(match) > 0 {
+		name := match[0][1]
+		if name == "multiple" {
+			return []graphrbac.ADGroup{
+				{
+					ObjectID:    to.StringPtr(fmt.Sprintf("00000000-1111-2222-3333-444444444444FAKE_GROUP-%s-1", name)),
+					DisplayName: to.StringPtr(name),
+				},
+				{
+					ObjectID:    to.StringPtr(fmt.Sprintf("00000000-1111-2222-3333-444444444444FAKE_GROUP-%s-2", name)),
+					DisplayName: to.StringPtr(name),
+				},
+			}, nil
+		}
+
+		return []graphrbac.ADGroup{
+			{
+				ObjectID:    to.StringPtr(fmt.Sprintf("00000000-1111-2222-3333-444444444444FAKE_GROUP-%s", name)),
+				DisplayName: to.StringPtr(name),
+			},
+		}, nil
+	}
+
+	return []graphrbac.ADGroup{}, nil
 }

--- a/client.go
+++ b/client.go
@@ -353,7 +353,7 @@ func (c *client) removeGroupMemberships(ctx context.Context, servicePrincipalObj
 	return merr.ErrorOrNil()
 }
 
-// groupObjectIDs is a helper for creating converting a list of AzureGroup
+// groupObjectIDs is a helper for converting a list of AzureGroup
 // objects to a list of their object IDs.
 func groupObjectIDs(groups []*AzureGroup) []string {
 	groupIDs := make([]string, 0, len(groups))

--- a/client.go
+++ b/client.go
@@ -321,9 +321,8 @@ func (c *client) addGroupMemberships(ctx context.Context, sp *graphrbac.ServiceP
 					),
 				})
 
-			// TODO is this right?
 			// Propagation delays within Azure can cause this error occasionally, so don't quit on it.
-			if err != nil && strings.Contains(err.Error(), "PrincipalNotFound") {
+			if err != nil && strings.Contains(err.Error(), "Request_ResourceNotFound") {
 				return nil, false, nil
 			}
 

--- a/path_roles.go
+++ b/path_roles.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/errwrap"
@@ -25,6 +26,7 @@ const (
 type roleEntry struct {
 	CredentialType      int           `json:"credential_type"` // Reserved. Always SP at this time.
 	AzureRoles          []*AzureRole  `json:"azure_roles"`
+	AzureGroups         []*AzureGroup `json:"azure_groups"`
 	ApplicationID       string        `json:"application_id"`
 	ApplicationObjectID string        `json:"application_object_id"`
 	TTL                 time.Duration `json:"ttl"`
@@ -38,6 +40,16 @@ type AzureRole struct {
 	RoleName string `json:"role_name"` // e.g. Owner
 	RoleID   string `json:"role_id"`   // e.g. /subscriptions/e0a207b2-.../providers/Microsoft.Authorization/roleDefinitions/de139f84-...
 	Scope    string `json:"scope"`     // e.g. /subscriptions/e0a207b2-...
+}
+
+// AzureGroup is an Azure Active Directory Group
+// (https://docs.microsoft.com/en-us/azure/role-based-access-control/overview).
+// GroupName and ObjectID are both traits of the group. ObjectID is the unique
+// identifier, but GroupName is more useful to a human (thought it is not
+// unique).
+type AzureGroup struct {
+	GroupName string `json:"group_name"` // e.g. MyGroup
+	ObjectID  string `json:"object_id"`  // e.g. 90820a30-352d-400f-89e5-2ca74ac14333
 }
 
 func pathsRole(b *azureSecretBackend) []*framework.Path {
@@ -56,6 +68,10 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 				"azure_roles": {
 					Type:        framework.TypeString,
 					Description: "JSON list of Azure roles to assign.",
+				},
+				"azure_groups": {
+					Type:        framework.TypeString,
+					Description: "JSON list of Azure groups to add the service principal to.",
 				},
 				"ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -95,9 +111,14 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 //
 // Dynamic Service Principal:
 //   Azure roles are checked for existence. The Azure role lookup step will allow the
-//   operator to provide a role name or ID.  ID is unambigious and will be used if provided.
+//   operator to provide a role name or ID. ID is unambigious and will be used if provided.
 //   Given just role name, a search will be performed and if exactly one match is found,
 //   that role will be used.
+
+//   Azure groups are checked for existence. The Azure groups lookup step will allow the
+//   operator to provide a groups name or ID. ID is unambigious and will be used if provided.
+//   Given just group name, a search will be performed and if exactly one match is found,
+//   that group will be used.
 //
 // Static Service Principal:
 //   The provided Application Object ID is checked for existence.
@@ -155,7 +176,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		role.ApplicationID = to.String(app.AppID)
 	}
 
-	// update and verify Azure roles, including looking up each role by ID or name.
+	// Parse the Azure roles
 	if roles, ok := d.GetOk("azure_roles"); ok {
 		parsedRoles := make([]*AzureRole, 0) // non-nil to avoid a "missing roles" error later
 
@@ -166,6 +187,18 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		role.AzureRoles = parsedRoles
 	}
 
+	// Parse the Azure groups
+	if groups, ok := d.GetOk("azure_groups"); ok {
+		parsedGroups := make([]*AzureGroup, 0) // non-nil to avoid a "missing groups" error later
+
+		err := jsonutil.DecodeJSON([]byte(groups.(string)), &parsedGroups)
+		if err != nil {
+			return logical.ErrorResponse(fmt.Sprintf("error parsing Azure groups '%s': %s", groups.(string), err.Error())), nil
+		}
+		role.AzureGroups = parsedGroups
+	}
+
+	// update and verify Azure roles, including looking up each role by ID or name.
 	roleSet := make(map[string]bool)
 	for _, r := range role.AzureRoles {
 		var roleDef authorization.RoleDefinition
@@ -202,8 +235,44 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		roleSet[rsKey] = true
 	}
 
-	if role.ApplicationObjectID == "" && len(role.AzureRoles) == 0 {
-		return logical.ErrorResponse("either Azure role definitions or an Application Object ID must be provided"), nil
+	// update and verify Azure groups, including looking up each group by ID or name.
+	groupSet := make(map[string]bool)
+	for _, r := range role.AzureGroups {
+		var groupDef graphrbac.ADGroup
+		if r.ObjectID != "" {
+			groupDef, err = client.provider.GetGroup(ctx, r.ObjectID)
+			if err != nil {
+				// TODO Figure out this error
+				if strings.Contains(err.Error(), "RoleDefinitionDoesNotExist") {
+					return logical.ErrorResponse(fmt.Sprintf("no group found for object_id: '%s'", r.ObjectID)), nil
+				}
+				return nil, errwrap.Wrapf("unable to lookup Azure group: {{err}}", err)
+			}
+		} else {
+			defs, err := client.findGroups(ctx, r.GroupName)
+			if err != nil {
+				return nil, errwrap.Wrapf("unable to lookup Azure group: {{err}}", err)
+			}
+			if l := len(defs); l == 0 {
+				return logical.ErrorResponse(fmt.Sprintf("no group found for group_name: '%s'", r.GroupName)), nil
+			} else if l > 1 {
+				return logical.ErrorResponse(fmt.Sprintf("multiple matches found for group_name: '%s'. Specify group by ObjectID instead.", r.GroupName)), nil
+			}
+			groupDef = defs[0]
+		}
+
+		groupDefID := to.String(groupDef.ObjectID)
+		groupDefName := to.String(groupDef.DisplayName)
+		r.GroupName, r.ObjectID = groupDefName, groupDefID
+
+		if groupSet[r.ObjectID] {
+			return logical.ErrorResponse(fmt.Sprintf("duplicate object_id '%s'", r.ObjectID)), nil
+		}
+		groupSet[r.ObjectID] = true
+	}
+
+	if role.ApplicationObjectID == "" && len(role.AzureRoles) == 0 && len(role.AzureGroups) == 0 {
+		return logical.ErrorResponse("either Azure role definitions, group definitions, or an Application Object ID must be provided"), nil
 	}
 
 	// save role
@@ -232,6 +301,7 @@ func (b *azureSecretBackend) pathRoleRead(ctx context.Context, req *logical.Requ
 	data["ttl"] = r.TTL / time.Second
 	data["max_ttl"] = r.MaxTTL / time.Second
 	data["azure_roles"] = r.AzureRoles
+	data["azure_groups"] = r.AzureGroups
 	data["application_object_id"] = r.ApplicationObjectID
 
 	return &logical.Response{
@@ -305,13 +375,14 @@ of Azure roles, which are used to control permissions to Azure resources.
 If the backend is mounted at "azure", you would create a Vault role at "azure/roles/my_role",
 and request credentials from "azure/creds/my_role".
 
-Each Vault role is configured with the standard ttl parameters and either a list of Azure
-roles and scopes, or an Application Object ID. Any Azure roles will be fetched during the
-Vault role creation and must exist for the request to succeed. Similarly, the Application
-Object ID will be verified if provided. When a used requests credentials against the Vault
-role, a new password will be created for the Application if an Application Object ID was
-configured. Otherwise, a new service principal will be created and the configured set of
-Azure roles are assigned to it.
+Each Vault role is configured with the standard ttl parameters and either a list
+of Azure roles and scopes, and a list of Azure groups, or an Application Object
+ID.  During the Vault role creation, any set Azure role, group, or Object ID
+will be fetched and verified, and therefore must exist for the request to
+succeed. When a user requests credentials against the Vault role, a new password
+will be created for the Application if an Application Object ID was configured.
+Otherwise, a new service principal will be created and the configured set of
+Azure roles are assigned to it and it will be added to the configured groups.
 `
 const roleListHelpSyn = `List existing roles.`
 const roleListHelpDesc = `List existing roles by name.`

--- a/path_roles.go
+++ b/path_roles.go
@@ -242,8 +242,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		if r.ObjectID != "" {
 			groupDef, err = client.provider.GetGroup(ctx, r.ObjectID)
 			if err != nil {
-				// TODO Figure out this error
-				if strings.Contains(err.Error(), "RoleDefinitionDoesNotExist") {
+				if strings.Contains(err.Error(), "Request_ResourceNotFound") {
 					return logical.ErrorResponse(fmt.Sprintf("no group found for object_id: '%s'", r.ObjectID)), nil
 				}
 				return nil, errwrap.Wrapf("unable to lookup Azure group: {{err}}", err)

--- a/path_roles.go
+++ b/path_roles.go
@@ -45,7 +45,7 @@ type AzureRole struct {
 // AzureGroup is an Azure Active Directory Group
 // (https://docs.microsoft.com/en-us/azure/role-based-access-control/overview).
 // GroupName and ObjectID are both traits of the group. ObjectID is the unique
-// identifier, but GroupName is more useful to a human (thought it is not
+// identifier, but GroupName is more useful to a human (though it is not
 // unique).
 type AzureGroup struct {
 	GroupName string `json:"group_name"` // e.g. MyGroup
@@ -182,7 +182,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 		err := jsonutil.DecodeJSON([]byte(roles.(string)), &parsedRoles)
 		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("error parsing Azure roles '%s': %s", roles.(string), err.Error())), nil
+			return logical.ErrorResponse("error parsing Azure roles '%s': %s", roles.(string), err.Error()), nil
 		}
 		role.AzureRoles = parsedRoles
 	}
@@ -193,7 +193,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 		err := jsonutil.DecodeJSON([]byte(groups.(string)), &parsedGroups)
 		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("error parsing Azure groups '%s': %s", groups.(string), err.Error())), nil
+			return logical.ErrorResponse("error parsing Azure groups '%s': %s", groups.(string), err.Error()), nil
 		}
 		role.AzureGroups = parsedGroups
 	}
@@ -206,7 +206,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			roleDef, err = client.provider.GetRoleByID(ctx, r.RoleID)
 			if err != nil {
 				if strings.Contains(err.Error(), "RoleDefinitionDoesNotExist") {
-					return logical.ErrorResponse(fmt.Sprintf("no role found for role_id: '%s'", r.RoleID)), nil
+					return logical.ErrorResponse("no role found for role_id: '%s'", r.RoleID), nil
 				}
 				return nil, errwrap.Wrapf("unable to lookup Azure role: {{err}}", err)
 			}
@@ -216,9 +216,9 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 				return nil, errwrap.Wrapf("unable to lookup Azure role: {{err}}", err)
 			}
 			if l := len(defs); l == 0 {
-				return logical.ErrorResponse(fmt.Sprintf("no role found for role_name: '%s'", r.RoleName)), nil
+				return logical.ErrorResponse("no role found for role_name: '%s'", r.RoleName), nil
 			} else if l > 1 {
-				return logical.ErrorResponse(fmt.Sprintf("multiple matches found for role_name: '%s'. Specify role by ID instead.", r.RoleName)), nil
+				return logical.ErrorResponse("multiple matches found for role_name: '%s'. Specify role by ID instead.", r.RoleName), nil
 			}
 			roleDef = defs[0]
 		}
@@ -230,7 +230,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 
 		rsKey := r.RoleID + "||" + r.Scope
 		if roleSet[rsKey] {
-			return logical.ErrorResponse(fmt.Sprintf("duplicate role_id and scope: '%s', '%s'", r.RoleID, r.Scope)), nil
+			return logical.ErrorResponse("duplicate role_id and scope: '%s', '%s'", r.RoleID, r.Scope), nil
 		}
 		roleSet[rsKey] = true
 	}
@@ -243,7 +243,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			groupDef, err = client.provider.GetGroup(ctx, r.ObjectID)
 			if err != nil {
 				if strings.Contains(err.Error(), "Request_ResourceNotFound") {
-					return logical.ErrorResponse(fmt.Sprintf("no group found for object_id: '%s'", r.ObjectID)), nil
+					return logical.ErrorResponse("no group found for object_id: '%s'", r.ObjectID), nil
 				}
 				return nil, errwrap.Wrapf("unable to lookup Azure group: {{err}}", err)
 			}
@@ -253,9 +253,9 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 				return nil, errwrap.Wrapf("unable to lookup Azure group: {{err}}", err)
 			}
 			if l := len(defs); l == 0 {
-				return logical.ErrorResponse(fmt.Sprintf("no group found for group_name: '%s'", r.GroupName)), nil
+				return logical.ErrorResponse("no group found for group_name: '%s'", r.GroupName), nil
 			} else if l > 1 {
-				return logical.ErrorResponse(fmt.Sprintf("multiple matches found for group_name: '%s'. Specify group by ObjectID instead.", r.GroupName)), nil
+				return logical.ErrorResponse("multiple matches found for group_name: '%s'. Specify group by ObjectID instead.", r.GroupName), nil
 			}
 			groupDef = defs[0]
 		}
@@ -265,7 +265,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		r.GroupName, r.ObjectID = groupDefName, groupDefID
 
 		if groupSet[r.ObjectID] {
-			return logical.ErrorResponse(fmt.Sprintf("duplicate object_id '%s'", r.ObjectID)), nil
+			return logical.ErrorResponse("duplicate object_id '%s'", r.ObjectID), nil
 		}
 		groupSet[r.ObjectID] = true
 	}

--- a/path_roles.go
+++ b/path_roles.go
@@ -374,14 +374,16 @@ of Azure roles, which are used to control permissions to Azure resources.
 If the backend is mounted at "azure", you would create a Vault role at "azure/roles/my_role",
 and request credentials from "azure/creds/my_role".
 
-Each Vault role is configured with the standard ttl parameters and either a list
-of Azure roles and scopes, and a list of Azure groups, or an Application Object
-ID.  During the Vault role creation, any set Azure role, group, or Object ID
-will be fetched and verified, and therefore must exist for the request to
-succeed. When a user requests credentials against the Vault role, a new password
-will be created for the Application if an Application Object ID was configured.
-Otherwise, a new service principal will be created and the configured set of
-Azure roles are assigned to it and it will be added to the configured groups.
+Each Vault role is configured with the standard ttl parameters and either an
+Application Object ID or a combination of Azure groups to make the service
+principal a member of, and Azure roles and scopes to assign the service
+principal to. During the Vault role creation, any set Azure role, group, or
+Object ID will be fetched and verified, and therefore must exist for the request
+to succeed. When a user requests credentials against the Vault role, a new
+password will be created for the Application if an Application Object ID was
+configured. Otherwise, a new service principal will be created and the
+configured set of Azure roles are assigned to it and it will be added to the
+configured groups.
 `
 const roleListHelpSyn = `List existing roles.`
 const roleListHelpDesc = `List existing roles by name.`

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -116,8 +116,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 	}
 
 	// Assign Azure group memberships to the new SP
-	gmIDs, err := c.addGroupMemberships(ctx, sp, role.AzureGroups)
-	if err != nil {
+	if err := c.addGroupMemberships(ctx, sp, role.AzureGroups); err != nil {
 		c.deleteApp(ctx, appObjID)
 		return nil, err
 	}
@@ -130,7 +129,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 		"app_object_id":        appObjID,
 		"sp_object_id":         sp.ObjectID,
 		"role_assignment_ids":  raIDs,
-		"group_membership_ids": gmIDs,
+		"group_membership_ids": groupObjectIDs(role.AzureGroups),
 		"role":                 roleName,
 	}
 

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -115,14 +115,23 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, c *client, role
 		return nil, err
 	}
 
+	// Assign Azure group memberships to the new SP
+	gmIDs, err := c.addGroupMemberships(ctx, sp, role.AzureGroups)
+	if err != nil {
+		c.deleteApp(ctx, appObjID)
+		return nil, err
+	}
+
 	data := map[string]interface{}{
 		"client_id":     appID,
 		"client_secret": password,
 	}
 	internalData := map[string]interface{}{
-		"app_object_id":       appObjID,
-		"role_assignment_ids": raIDs,
-		"role":                roleName,
+		"app_object_id":        appObjID,
+		"sp_object_id":         sp.ObjectID,
+		"role_assignment_ids":  raIDs,
+		"group_membership_ids": gmIDs,
+		"role":                 roleName,
 	}
 
 	return b.Secret(SecretTypeSP).Response(data, internalData), nil
@@ -184,11 +193,29 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 
 	appObjectID := appObjectIDRaw.(string)
 
+	// Get the service principal object ID. Only set if using dynamic service
+	// principals.
+	var spObjectID string
+	if spObjectIDRaw, ok := req.Secret.InternalData["sp_object_id"]; ok {
+		spObjectID = spObjectIDRaw.(string)
+	}
+
 	var raIDs []string
 	if req.Secret.InternalData["role_assignment_ids"] != nil {
 		for _, v := range req.Secret.InternalData["role_assignment_ids"].([]interface{}) {
 			raIDs = append(raIDs, v.(string))
 		}
+	}
+
+	var gmIDs []string
+	if req.Secret.InternalData["group_membership_ids"] != nil {
+		for _, v := range req.Secret.InternalData["group_membership_ids"].([]interface{}) {
+			gmIDs = append(gmIDs, v.(string))
+		}
+	}
+
+	if len(gmIDs) != 0 && spObjectID == "" {
+		return nil, errors.New("internal data 'sp_object_id' not found")
 	}
 
 	c, err := b.getClient(ctx, req.Storage)
@@ -199,6 +226,13 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 	// unassigning roles is effectively a garbage collection operation. Errors will be noted but won't fail the
 	// revocation process. Deleting the app, however, *is* required to consider the secret revoked.
 	if err := c.unassignRoles(ctx, raIDs); err != nil {
+		resp.AddWarning(err.Error())
+	}
+
+	// removing group membership is effectively a garbage collection
+	// operation. Errors will be noted but won't fail the revocation process.
+	// Deleting the app, however, *is* required to consider the secret revoked.
+	if err := c.removeGroupMemberships(ctx, spObjectID, gmIDs); err != nil {
 		resp.AddWarning(err.Error())
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -16,6 +16,7 @@ import (
 type AzureProvider interface {
 	ApplicationsClient
 	ServicePrincipalsClient
+	ADGroupsClient
 	RoleAssignmentsClient
 	RoleDefinitionsClient
 }
@@ -33,6 +34,13 @@ type ApplicationsClient interface {
 
 type ServicePrincipalsClient interface {
 	CreateServicePrincipal(ctx context.Context, parameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error)
+}
+
+type ADGroupsClient interface {
+	AddGroupMember(ctx context.Context, groupObjectID string, parameters graphrbac.GroupAddMemberParameters) (result autorest.Response, err error)
+	RemoveGroupMember(ctx context.Context, groupObjectID, memberObjectID string) (result autorest.Response, err error)
+	GetGroup(ctx context.Context, objectID string) (result graphrbac.ADGroup, err error)
+	ListGroups(ctx context.Context, filter string) (result []graphrbac.ADGroup, err error)
 }
 
 type RoleAssignmentsClient interface {
@@ -55,10 +63,11 @@ type RoleDefinitionsClient interface {
 type provider struct {
 	settings *clientSettings
 
-	appClient *graphrbac.ApplicationsClient
-	spClient  *graphrbac.ServicePrincipalsClient
-	raClient  *authorization.RoleAssignmentsClient
-	rdClient  *authorization.RoleDefinitionsClient
+	appClient    *graphrbac.ApplicationsClient
+	spClient     *graphrbac.ServicePrincipalsClient
+	groupsClient *graphrbac.GroupsClient
+	raClient     *authorization.RoleAssignmentsClient
+	rdClient     *authorization.RoleDefinitionsClient
 }
 
 // newAzureProvider creates an azureProvider, backed by Azure client objects for underlying services.
@@ -84,6 +93,10 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 	spClient.Authorizer = authorizer
 	spClient.AddToUserAgent(userAgent)
 
+	groupsClient := graphrbac.NewGroupsClient(settings.TenantID)
+	groupsClient.Authorizer = authorizer
+	groupsClient.AddToUserAgent(userAgent)
+
 	// build clients that use the Resource Manager endpoint
 	authorizer, err = getAuthorizer(settings, settings.Environment.ResourceManagerEndpoint)
 	if err != nil {
@@ -101,10 +114,11 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 	p := &provider{
 		settings: settings,
 
-		appClient: &appClient,
-		spClient:  &spClient,
-		raClient:  &raClient,
-		rdClient:  &rdClient,
+		appClient:    &appClient,
+		spClient:     &spClient,
+		groupsClient: &groupsClient,
+		raClient:     &raClient,
+		rdClient:     &rdClient,
 	}
 
 	return p, nil
@@ -200,6 +214,31 @@ func (p *provider) DeleteRoleAssignmentByID(ctx context.Context, roleAssignmentI
 func (p *provider) ListRoleAssignments(ctx context.Context, filter string) ([]authorization.RoleAssignment, error) {
 	page, err := p.raClient.List(ctx, filter)
 
+	if err != nil {
+		return nil, err
+	}
+
+	return page.Values(), nil
+}
+
+// AddGroupMember adds a member to a AAD Group.
+func (p *provider) AddGroupMember(ctx context.Context, groupObjectID string, parameters graphrbac.GroupAddMemberParameters) (result autorest.Response, err error) {
+	return p.groupsClient.AddMember(ctx, groupObjectID, parameters)
+}
+
+// RemoveGroupMember removes a member from a AAD Group.
+func (p *provider) RemoveGroupMember(ctx context.Context, groupObjectID, memberObjectID string) (result autorest.Response, err error) {
+	return p.groupsClient.RemoveMember(ctx, groupObjectID, memberObjectID)
+}
+
+// GetGroup gets group information from the directory.
+func (p *provider) GetGroup(ctx context.Context, objectID string) (result graphrbac.ADGroup, err error) {
+	return p.groupsClient.Get(ctx, objectID)
+}
+
+// ListGroups gets list of groups for the current tenant.
+func (p *provider) ListGroups(ctx context.Context, filter string) (result []graphrbac.ADGroup, err error) {
+	page, err := p.groupsClient.List(ctx, filter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR supports adding the dynamic service principal to an Azure Active Directory group. The group can be specified by name or by object_id. The required permissions to add to a group are `Azure Active Directory Graph / Directory.ReadWrite.All`. I have tested this by building the plugin and generating a service principal, seeing it be added to the group, and removed when I revoke the lease.

For the error codes, I tested by requesting non-existing service providers and mapping the errors. I have not added anything to the integration test since I do not have access to that environment. 

Additional Role Config is as follows:
```
"azure_groups": [
 	{
 		"group_name": "", 
 		"object_id": "239b11fe-6adf-409a-b231-08b918e9de23"
 	},
 	{
 		"group_name": "bar",
 		"object_id": "" // Looked up
 	}
]
```