### PR TITLE
Fix integration test

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/vault/sdk/logical"
+
 	"github.com/go-test/deep"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -59,4 +61,15 @@ func generateUUID() string {
 		panic(err)
 	}
 	return u
+}
+
+// fakeSaveLoad will simulate the JSON encoding/decoding process that secrets will normally go
+// through. If not done, some of the secret data will retain richer data types (e.g. pointers)
+// than would normally be seen.
+func fakeSaveLoad(s *logical.Secret) {
+	enc := encodeJSON(s)
+
+	if err := jsonutil.DecodeJSON([]byte(enc), s); err != nil {
+		panic(err)
+	}
 }

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -673,18 +672,4 @@ func TestCredentialInteg(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-}
-
-// fakeSaveLoad will simulate the JSON encoding/decoding process that secrets will normally go
-// through. If not done, some of the secret data will retain richer data types (e.g. pointers)
-// than would normally be seen.
-func fakeSaveLoad(s *logical.Secret) {
-	enc, err := jsonutil.EncodeJSON(s)
-	if err != nil {
-		panic(err)
-	}
-
-	if err := jsonutil.DecodeJSON(enc, s); err != nil {
-		panic(err)
-	}
 }


### PR DESCRIPTION
The core issue is that normally secret data is persisted via JSON, which ends up (as expected) removing type data (e.g. a string pointer becomes a JSON string and is still a string in the `map[string]interface{}` after being read. Test paths aren't going through that persistence flow which was causing some errors.