### PR TITLE
Forward service principal creation

### DIFF
--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -46,9 +46,14 @@ func pathServicePrincipal(b *azureSecretBackend) *framework.Path {
 				Description: "Name of the Vault role",
 			},
 		},
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: b.pathSPRead,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback:                    b.pathSPRead,
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
+			},
 		},
+
 		HelpSynopsis:    pathServicePrincipalHelpSyn,
 		HelpDescription: pathServicePrincipalHelpDesc,
 	}


### PR DESCRIPTION
Avoids side-effect of registering Azure Applications as part of creating service principals, which later fail to complete because secondaries can't write to state. 

# Overview

- Creating dynamic credentials is a multi-step process where an application is first registered in Azure, and then service principals assigned to it. These steps can succeed in Azure but their information fail to save to state, triggering `logical.ErrReadOnly` and forwarding the request to the primary. 
- The primary then performs the request, resulting in duplicate app registrations that are orphaned 



A high level description of the contribution, including:

- The `GET /creds/:rolename` path will now explicitly forward to the primary, instead of waiting for the implicitly triggered forwarding when the `logical.ErrReadOnly` error is hit

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet - N/A
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests) - N/A
- [x] Backwards compatible
