### PR TITLE
set GUID in user-agent

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/version"
-	"github.com/ryboe/q"
 )
 
 // AzureProvider is an interface to access underlying Azure client objects and supporting services.
@@ -105,7 +104,6 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 		vaultIDString = "; b2c13ec1-60e8-4733-9a76-88dbb2ce2471)"
 	}
 	userAgent = strings.Replace(userAgent, ")", vaultIDString, 1)
-	q.Q(userAgent)
 
 	appClient := graphrbac.NewApplicationsClient(settings.TenantID)
 	appClient.Authorizer = authorizer

--- a/provider.go
+++ b/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/version"
+	"github.com/ryboe/q"
 )
 
 // AzureProvider is an interface to access underlying Azure client objects and supporting services.
@@ -87,7 +88,7 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 		userAgent = useragent.String()
 	}
 
-	// Set's a unique ID in the user-agento
+	// Sets a unique ID in the user-agent
 	// Normal user-agent looks like this:
 	//
 	// Vault/1.6.0 (+https://www.vaultproject.io/; azure-secrets; go1.15.7)
@@ -104,6 +105,7 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 		vaultIDString = "; b2c13ec1-60e8-4733-9a76-88dbb2ce2471)"
 	}
 	userAgent = strings.Replace(userAgent, ")", vaultIDString, 1)
+	q.Q(userAgent)
 
 	appClient := graphrbac.NewApplicationsClient(settings.TenantID)
 	appClient.Authorizer = authorizer

--- a/provider.go
+++ b/provider.go
@@ -2,12 +2,14 @@ package azuresecrets
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
+	"github.com/hashicorp/vault/sdk/version"
 )
 
 // AzureProvider is an interface to access underlying Azure client objects and supporting services.
@@ -84,6 +86,24 @@ func newAzureProvider(settings *clientSettings) (AzureProvider, error) {
 	} else {
 		userAgent = useragent.String()
 	}
+
+	// Set's a unique ID in the user-agento
+	// Normal user-agent looks like this:
+	//
+	// Vault/1.6.0 (+https://www.vaultproject.io/; azure-secrets; go1.15.7)
+	//
+	// Here we append a unique code if it's an enterprise version, where
+	// VersionMetadata will contain a non-empty string like "ent" or "prem".
+	// Otherwise use the default identifier for OSS Vault. The end result looks
+	// like so:
+	//
+	// Vault/1.6.0 (+https://www.vaultproject.io/; azure-secrets; go1.15.7; b2c13ec1-60e8-4733-9a76-88dbb2ce2471)
+	vaultIDString := "; 15cd22ce-24af-43a4-aa83-4c1a36a4b177)"
+	ver := version.GetVersion()
+	if ver.VersionMetadata != "" {
+		vaultIDString = "; b2c13ec1-60e8-4733-9a76-88dbb2ce2471)"
+	}
+	userAgent = strings.Replace(userAgent, ")", vaultIDString, 1)
 
 	appClient := graphrbac.NewApplicationsClient(settings.TenantID)
 	appClient.Authorizer = authorizer


### PR DESCRIPTION
# Overview

Adds a GUID into the user-agent header, depending on the Vault version (enterprise or not)
