### PR TITLE
Use the MS Graph API for atomic add/remove password operations

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -14,7 +14,7 @@ import (
 type azureSecretBackend struct {
 	*framework.Backend
 
-	getProvider func(*clientSettings) (AzureProvider, error)
+	getProvider func(*clientSettings, bool, passwords) (AzureProvider, error)
 	client      *client
 	settings    *clientSettings
 	lock        sync.RWMutex
@@ -121,14 +121,14 @@ func (b *azureSecretBackend) getClient(ctx context.Context, s logical.Storage) (
 		b.settings = settings
 	}
 
-	p, err := b.getProvider(b.settings)
-	if err != nil {
-		return nil, err
-	}
-
 	passwords := passwords{
 		policyGenerator: b.System(),
 		policyName:      config.PasswordPolicy,
+	}
+
+	p, err := b.getProvider(b.settings, config.UseMsGraphAPI, passwords)
+	if err != nil {
+		return nil, err
 	}
 
 	c := &client{

--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func (c *client) Valid() bool {
 // createApp creates a new Azure application.
 // An Application is a needed to create service principals used by
 // the caller for authentication.
-func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err error) {
+func (c *client) createApp(ctx context.Context) (app *ApplicationResult, err error) {
 	name, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, err
@@ -52,14 +52,7 @@ func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err
 
 	name = appNamePrefix + name
 
-	appURL := fmt.Sprintf("https://%s", name)
-
-	result, err := c.provider.CreateApplication(ctx, graphrbac.ApplicationCreateParameters{
-		AvailableToOtherTenants: to.BoolPtr(false),
-		DisplayName:             to.StringPtr(name),
-		Homepage:                to.StringPtr(appURL),
-		IdentifierUris:          to.StringSlicePtr([]string{appURL}),
-	})
+	result, err := c.provider.CreateApplication(ctx, name)
 
 	return &result, err
 }
@@ -67,7 +60,7 @@ func (c *client) createApp(ctx context.Context) (app *graphrbac.Application, err
 // createSP creates a new service principal.
 func (c *client) createSP(
 	ctx context.Context,
-	app *graphrbac.Application,
+	app *ApplicationResult,
 	duration time.Duration) (svcPrinc *graphrbac.ServicePrincipal, password string, err error) {
 
 	// Generate a random key (which must be a UUID) and password
@@ -114,85 +107,26 @@ func (c *client) createSP(
 }
 
 // addAppPassword adds a new password to an App's credentials list.
-func (c *client) addAppPassword(ctx context.Context, appObjID string, duration time.Duration) (keyID string, password string, err error) {
-	keyID, err = uuid.GenerateUUID()
+func (c *client) addAppPassword(ctx context.Context, appObjID string, expiresIn time.Duration) (string, string, error) {
+	exp := date.Time{Time: time.Now().Add(expiresIn)}
+	resp, err := c.provider.AddApplicationPassword(ctx, appObjID, "vault-plugin-secrets-azure", exp)
 	if err != nil {
-		return "", "", err
-	}
-
-	// Key IDs are not secret, and they're a convenient way for an operator to identify Vault-generated
-	// passwords. These must be UUIDs, so the three leading bytes will be used as an indicator.
-	keyID = "ffffff" + keyID[6:]
-
-	password, err = c.passwords.generate(ctx)
-	if err != nil {
-		return "", "", err
-	}
-
-	now := time.Now().UTC()
-	cred := graphrbac.PasswordCredential{
-		StartDate: &date.Time{Time: now},
-		EndDate:   &date.Time{Time: now.Add(duration)},
-		KeyID:     to.StringPtr(keyID),
-		Value:     to.StringPtr(password),
-	}
-
-	// Load current credentials
-	resp, err := c.provider.ListApplicationPasswordCredentials(ctx, appObjID)
-	if err != nil {
-		return "", "", errwrap.Wrapf("error fetching credentials: {{err}}", err)
-	}
-	curCreds := *resp.Value
-
-	// Add and save credentials
-	curCreds = append(curCreds, cred)
-
-	if _, err := c.provider.UpdateApplicationPasswordCredentials(ctx, appObjID,
-		graphrbac.PasswordCredentialsUpdateParameters{
-			Value: &curCreds,
-		},
-	); err != nil {
 		if strings.Contains(err.Error(), "size of the object has exceeded its limit") {
 			err = errors.New("maximum number of Application passwords reached")
 		}
 		return "", "", errwrap.Wrapf("error updating credentials: {{err}}", err)
 	}
 
-	return keyID, password, nil
+	return to.String(resp.KeyID), to.String(resp.SecretText), nil
 }
 
 // deleteAppPassword removes a password, if present, from an App's credentials list.
 func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) error {
-	// Load current credentials
-	resp, err := c.provider.ListApplicationPasswordCredentials(ctx, appObjID)
-	if err != nil {
-		return errwrap.Wrapf("error fetching credentials: {{err}}", err)
-	}
-	curCreds := *resp.Value
-
-	// Remove credential
-	found := false
-	for i := range curCreds {
-		if to.String(curCreds[i].KeyID) == keyID {
-			curCreds[i] = curCreds[len(curCreds)-1]
-			curCreds = curCreds[:len(curCreds)-1]
-			found = true
-			break
+	if _, err := c.provider.RemoveApplicationPassword(ctx, appObjID, keyID); err != nil {
+		if strings.Contains(err.Error(), "No password credential found with keyId") {
+			return nil
 		}
-	}
-
-	// KeyID is not present, so nothing to do
-	if !found {
-		return nil
-	}
-
-	// Save new credentials list
-	if _, err := c.provider.UpdateApplicationPasswordCredentials(ctx, appObjID,
-		graphrbac.PasswordCredentialsUpdateParameters{
-			Value: &curCreds,
-		},
-	); err != nil {
-		return errwrap.Wrapf("error updating credentials: {{err}}", err)
+		return errwrap.Wrapf("error removing credentials: {{err}}", err)
 	}
 
 	return nil

--- a/graph_api_client.go
+++ b/graph_api_client.go
@@ -1,0 +1,334 @@
+package azuresecrets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const (
+	// defaultGraphMicrosoftComURI is the default URI used for the service MS Graph API
+	defaultGraphMicrosoftComURI = "https://graph.microsoft.com"
+)
+
+type msGraphApplicationsClient struct {
+	authorization.BaseClient
+}
+
+func newMSGraphApplicationClient(subscriptionId string) msGraphApplicationsClient {
+	return msGraphApplicationsClient{authorization.NewWithBaseURI(defaultGraphMicrosoftComURI, subscriptionId)}
+}
+
+func (p *msGraphApplicationsClient) GetApplication(ctx context.Context, applicationObjectID string) (result ApplicationResult, err error) {
+	req, err := p.getApplicationPreparer(ctx, applicationObjectID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "GetApplication", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := p.getApplicationSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure sending request")
+		return
+	}
+
+	result, err = p.getApplicationResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateApplication create a new Azure application object.
+func (p *msGraphApplicationsClient) CreateApplication(ctx context.Context, displayName string) (result ApplicationResult, err error) {
+	req, err := p.createApplicationPreparer(ctx, displayName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := p.createApplicationSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure sending request")
+		return
+	}
+
+	result, err = p.createApplicationResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// DeleteApplication deletes an Azure application object.
+// This will in turn remove the service principal (but not the role assignments).
+func (p *msGraphApplicationsClient) DeleteApplication(ctx context.Context, applicationObjectID string) (result autorest.Response, err error) {
+	req, err := p.deleteApplicationPreparer(ctx, applicationObjectID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := p.deleteApplicationSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
+		return
+	}
+
+	result, err = p.deleteApplicationResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (p *msGraphApplicationsClient) AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (result PasswordCredentialResult, err error) {
+	req, err := p.addPasswordPreparer(ctx, applicationObjectID, displayName, endDateTime)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := p.addPasswordSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure sending request")
+		return
+	}
+
+	result, err = p.addPasswordResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (p *msGraphApplicationsClient) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (result autorest.Response, err error) {
+	req, err := p.removePasswordPreparer(ctx, applicationObjectID, keyID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := p.removePasswordSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure sending request")
+		return
+	}
+
+	result, err = p.removePasswordResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client msGraphApplicationsClient) getApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}", pathParameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client msGraphApplicationsClient) getApplicationSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client msGraphApplicationsClient) getApplicationResponder(resp *http.Response) (result ApplicationResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+func (client msGraphApplicationsClient) addPasswordPreparer(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	parameters := struct {
+		PasswordCredential *passwordCredential `json:"passwordCredential"`
+	}{
+		PasswordCredential: &passwordCredential{
+			DisplayName: to.StringPtr(displayName),
+			EndDate:     &endDateTime,
+		},
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}/addPassword", pathParameters),
+		autorest.WithJSON(parameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client msGraphApplicationsClient) addPasswordSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client msGraphApplicationsClient) addPasswordResponder(resp *http.Response) (result PasswordCredentialResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+func (client msGraphApplicationsClient) removePasswordPreparer(ctx context.Context, applicationObjectID string, keyID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	parameters := struct {
+		KeyID string `json:"keyId"`
+	}{
+		KeyID: keyID,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}/removePassword", pathParameters),
+		autorest.WithJSON(parameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client msGraphApplicationsClient) removePasswordSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client msGraphApplicationsClient) removePasswordResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+func (client msGraphApplicationsClient) createApplicationPreparer(ctx context.Context, displayName string) (*http.Request, error) {
+	parameters := struct {
+		DisplayName *string `json:"displayName"`
+	}{
+		DisplayName: to.StringPtr(displayName),
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPath("/v1.0/applications"),
+		autorest.WithJSON(parameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client msGraphApplicationsClient) createApplicationSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client msGraphApplicationsClient) createApplicationResponder(resp *http.Response) (result ApplicationResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+func (client msGraphApplicationsClient) deleteApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"applicationObjectId": autorest.Encode("path", applicationObjectID),
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/v1.0/applications/{applicationObjectId}", pathParameters),
+		client.Authorizer.WithAuthorization())
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func (client msGraphApplicationsClient) deleteApplicationSender(req *http.Request) (*http.Response, error) {
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
+}
+
+func (client msGraphApplicationsClient) deleteApplicationResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
+type passwordCredential struct {
+	DisplayName *string `json:"displayName"`
+	// StartDate - Start date.
+	StartDate *date.Time `json:"startDateTime,omitempty"`
+	// EndDate - End date.
+	EndDate *date.Time `json:"endDateTime,omitempty"`
+	// KeyID - Key ID.
+	KeyID *string `json:"keyId,omitempty"`
+	// Value - Key value.
+	SecretText *string `json:"secretText,omitempty"`
+}
+
+type PasswordCredentialResult struct {
+	autorest.Response `json:"-"`
+
+	passwordCredential
+}
+
+type ApplicationResult struct {
+	autorest.Response `json:"-"`
+
+	AppID               *string               `json:"appId,omitempty"`
+	ID                  *string               `json:"id,omitempty"`
+	PasswordCredentials []*passwordCredential `json:"passwordCredentials,omitempty"`
+}

--- a/path_config.go
+++ b/path_config.go
@@ -24,6 +24,7 @@ type azureConfig struct {
 	ClientSecret   string `json:"client_secret"`
 	Environment    string `json:"environment"`
 	PasswordPolicy string `json:"password_policy"`
+	UseMsGraphAPI  bool   `json:"use_microsoft_graph_api"`
 }
 
 func pathConfig(b *azureSecretBackend) *framework.Path {
@@ -58,6 +59,10 @@ func pathConfig(b *azureSecretBackend) *framework.Path {
 			"password_policy": &framework.FieldSchema{
 				Type:        framework.TypeString,
 				Description: "Name of the password policy to use to generate passwords for dynamic credentials.",
+			},
+			"use_microsoft_graph_api": &framework.FieldSchema{
+				Type:        framework.TypeBool,
+				Description: "Enable usage of the Microsoft Graph API over the deprecated Azure AD Graph API.",
 			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
@@ -112,6 +117,10 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 		config.ClientSecret = clientSecret.(string)
 	}
 
+	if useMsGraphApi, ok := data.GetOk("use_microsoft_graph_api"); ok {
+		config.UseMsGraphAPI = useMsGraphApi.(bool)
+	}
+
 	config.PasswordPolicy = data.Get("password_policy").(string)
 
 	if merr.ErrorOrNil() != nil {
@@ -136,10 +145,11 @@ func (b *azureSecretBackend) pathConfigRead(ctx context.Context, req *logical.Re
 
 	resp := &logical.Response{
 		Data: map[string]interface{}{
-			"subscription_id": config.SubscriptionID,
-			"tenant_id":       config.TenantID,
-			"environment":     config.Environment,
-			"client_id":       config.ClientID,
+			"subscription_id":         config.SubscriptionID,
+			"tenant_id":               config.TenantID,
+			"environment":             config.Environment,
+			"client_id":               config.ClientID,
+			"use_microsoft_graph_api": config.UseMsGraphAPI,
 		},
 	}
 	return resp, nil

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -12,11 +12,12 @@ func TestConfig(t *testing.T) {
 
 	// Test valid config
 	config := map[string]interface{}{
-		"subscription_id": "a228ceec-bf1a-4411-9f95-39678d8cdb34",
-		"tenant_id":       "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
-		"client_id":       "testClientId",
-		"client_secret":   "testClientSecret",
-		"environment":     "AZURECHINACLOUD",
+		"subscription_id":         "a228ceec-bf1a-4411-9f95-39678d8cdb34",
+		"tenant_id":               "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
+		"client_id":               "testClientId",
+		"client_secret":           "testClientSecret",
+		"environment":             "AZURECHINACLOUD",
+		"use_microsoft_graph_api": false,
 	}
 
 	testConfigCreate(t, b, s, config)
@@ -54,11 +55,12 @@ func TestConfigDelete(t *testing.T) {
 
 	// Test valid config
 	config := map[string]interface{}{
-		"subscription_id": "a228ceec-bf1a-4411-9f95-39678d8cdb34",
-		"tenant_id":       "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
-		"client_id":       "testClientId",
-		"client_secret":   "testClientSecret",
-		"environment":     "AZURECHINACLOUD",
+		"subscription_id":         "a228ceec-bf1a-4411-9f95-39678d8cdb34",
+		"tenant_id":               "7ac36e27-80fc-4209-a453-e8ad83dc18c2",
+		"client_id":               "testClientId",
+		"client_secret":           "testClientSecret",
+		"environment":             "AZURECHINACLOUD",
+		"use_microsoft_graph_api": false,
 	}
 
 	testConfigCreate(t, b, s, config)
@@ -79,10 +81,11 @@ func TestConfigDelete(t *testing.T) {
 	}
 
 	config = map[string]interface{}{
-		"subscription_id": "",
-		"tenant_id":       "",
-		"client_id":       "",
-		"environment":     "",
+		"subscription_id":         "",
+		"tenant_id":               "",
+		"client_id":               "",
+		"environment":             "",
+		"use_microsoft_graph_api": false,
 	}
 	testConfigRead(t, b, s, config)
 }

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -105,7 +105,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 		return nil, err
 	}
 	appID := to.String(app.AppID)
-	appObjID := to.String(app.ObjectID)
+	appObjID := to.String(app.ID)
 
 	// Write a WAL entry in case the SP create process doesn't complete
 	walID, err := framework.PutWAL(ctx, s, walAppKey, &walApp{

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -59,7 +59,7 @@ func TestSP_WAL_Cleanup(t *testing.T) {
 
 	// overwrite the normal test backend provider with the errMockProvider
 	errMockProvider := newErrMockProvider()
-	b.getProvider = func(s *clientSettings) (AzureProvider, error) {
+	b.getProvider = func(s *clientSettings, useMsGraphApi bool, p passwords) (AzureProvider, error) {
 		return errMockProvider, nil
 	}
 
@@ -271,8 +271,8 @@ func TestStaticSPRead(t *testing.T) {
 		assertErrorIsNil(t, err)
 
 		keyID := resp.Secret.InternalData["key_id"].(string)
-		if !strings.HasPrefix(keyID, "ffffff") {
-			t.Fatalf("expected prefix 'ffffff': %s", keyID)
+		if len(keyID) == 0 {
+			t.Fatalf("expected keyId to not be empty")
 		}
 
 		client, err := b.getClient(context.Background(), s)
@@ -413,8 +413,8 @@ func TestStaticSPRevoke(t *testing.T) {
 	assertErrorIsNil(t, err)
 
 	keyID := resp.Secret.InternalData["key_id"].(string)
-	if !strings.HasPrefix(keyID, "ffffff") {
-		t.Fatalf("expected prefix 'ffffff': %s", keyID)
+	if len(keyID) == 0 {
+		t.Fatalf("expected keyId to not be empty")
 	}
 
 	client, err := b.getClient(context.Background(), s)
@@ -733,7 +733,7 @@ func TestCredentialInteg(t *testing.T) {
 		for i := 0; i < 8; i++ {
 			// New credentials are only tested during an actual operation, not provider creation.
 			// This step should never fail.
-			p, err := newAzureProvider(settings)
+			p, err := newAzureProvider(settings, true, passwords{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Azure Active Directory Graph API, now deprecated, does not provide
support for atomically creating/removing passwords on an application. As
a result, there is a race conditions that can occur when creds are being
created for roles configured with an existing service principal that
is configured on multiple mounts or across multiple Vault clusters.

Unfortunately, [`Azure/azure-sdk-for-go`](https://github.com/Azure/azure-sdk-for-go) does not yet offer a MS Graph API 
client, therefore, this PR utilizes [`Azure/go-autorest`](https://github.com/Azure/go-autorest) to construct a client the 
same as [`Azure/azure-sdk-for-go`](https://github.com/Azure/azure-sdk-for-go).

This changeset preserves using the AAD Graph API by default but provides
a mount configuration option for toggling to the new MS Graph API. This
is because the two APIs require different API permissions. This allows
users to upgrade to the new plugin version and then switch to the new
API.

Additionally, although using the MS Graph API is a net benefit, it
itself has reliability issues when handling multiple requests in
parallel. More details can be found in
https://github.com/mdgreenfield/microsoft-graph-api-reliability and I am
working with Microsoft to try to get some of these reliability issues
resolved.

Fixes #58
