### PR TITLE
Code Cleanup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,15 +24,15 @@ type AzureProvider interface {
 	DeleteRoleAssignmentByID(ctx context.Context, roleID string) (authorization.RoleAssignment, error)
 
 	ListRoleDefinitions(ctx context.Context, scope string, filter string) ([]authorization.RoleDefinition, error)
-	GetRoleDefinitionByID(ctx context.Context, roleID string) (result authorization.RoleDefinition, err error)
+	GetRoleDefinitionByID(ctx context.Context, roleID string) (authorization.RoleDefinition, error)
 }
 
 type ApplicationsClient interface {
-	GetApplication(ctx context.Context, applicationObjectID string) (result ApplicationResult, err error)
-	CreateApplication(ctx context.Context, displayName string) (result ApplicationResult, err error)
-	DeleteApplication(ctx context.Context, applicationObjectID string) (autorest.Response, error)
-	AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (result PasswordCredentialResult, err error)
-	RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (result autorest.Response, err error)
+	GetApplication(ctx context.Context, applicationObjectID string) (ApplicationResult, error)
+	CreateApplication(ctx context.Context, displayName string) (ApplicationResult, error)
+	DeleteApplication(ctx context.Context, applicationObjectID string) error
+	AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (PasswordCredentialResult, error)
+	RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) error
 }
 
 type PasswordCredential struct {

--- a/api/application_aad.go
+++ b/api/application_aad.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-uuid"
 )
 
@@ -89,7 +88,7 @@ func (a *ActiveDirectoryApplicationClient) AddApplicationPassword(ctx context.Co
 	// Load current credentials
 	resp, err := a.Client.ListPasswordCredentials(ctx, applicationObjectID)
 	if err != nil {
-		return PasswordCredentialResult{}, errwrap.Wrapf("error fetching credentials: {{err}}", err)
+		return PasswordCredentialResult{}, fmt.Errorf("error fetching credentials: %w", err)
 	}
 	curCreds := *resp.Value
 
@@ -104,7 +103,7 @@ func (a *ActiveDirectoryApplicationClient) AddApplicationPassword(ctx context.Co
 		if strings.Contains(err.Error(), "size of the object has exceeded its limit") {
 			err = errors.New("maximum number of Application passwords reached")
 		}
-		return PasswordCredentialResult{}, errwrap.Wrapf("error updating credentials: {{err}}", err)
+		return PasswordCredentialResult{}, fmt.Errorf("error updating credentials: %w", err)
 	}
 
 	result = PasswordCredentialResult{
@@ -123,7 +122,7 @@ func (a *ActiveDirectoryApplicationClient) RemoveApplicationPassword(ctx context
 	// Load current credentials
 	resp, err := a.Client.ListPasswordCredentials(ctx, applicationObjectID)
 	if err != nil {
-		return errwrap.Wrapf("error fetching credentials: {{err}}", err)
+		return fmt.Errorf("error fetching credentials: %w", err)
 	}
 	curCreds := *resp.Value
 
@@ -150,7 +149,7 @@ func (a *ActiveDirectoryApplicationClient) RemoveApplicationPassword(ctx context
 		},
 	)
 	if err != nil {
-		return errwrap.Wrapf("error updating credentials: {{err}}", err)
+		return fmt.Errorf("error updating credentials: %w", err)
 	}
 
 	return nil

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -220,9 +220,7 @@ func (c AppClient) addPasswordResponder(resp *http.Response) (result PasswordCre
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result = PasswordCredentialResult{
-		Response: autorest.Response{Response: resp},
-	}
+	result.Response = autorest.Response{Response: resp}
 	return result, err
 }
 
@@ -259,9 +257,7 @@ func (c AppClient) removePasswordResponder(resp *http.Response) (result autorest
 		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result = autorest.Response{
-		Response: resp,
-	}
+	result.Response = resp
 	return result, err
 }
 
@@ -294,9 +290,7 @@ func (c AppClient) createApplicationResponder(resp *http.Response) (result Appli
 		azure.WithErrorUnlessStatusCode(http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result = ApplicationResult{
-		Response: autorest.Response{Response: resp},
-	}
+	result.Response = autorest.Response{Response: resp}
 	return result, nil
 }
 

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -95,24 +95,22 @@ func (c *AppClient) CreateApplication(ctx context.Context, displayName string) (
 
 // DeleteApplication deletes an Azure application object.
 // This will in turn remove the service principal (but not the role assignments).
-func (c *AppClient) DeleteApplication(ctx context.Context, applicationObjectID string) (result autorest.Response, err error) {
+func (c *AppClient) DeleteApplication(ctx context.Context, applicationObjectID string) (err error) {
 	req, err := c.deleteApplicationPreparer(ctx, applicationObjectID)
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", nil, "Failure preparing request")
+		return autorest.NewErrorWithError(err, "provider", "DeleteApplication", nil, "Failure preparing request")
 	}
 
 	resp, err := c.deleteApplicationSender(req)
 	if err != nil {
-		result = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
+		return autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
 	}
 
-	result, err = c.deleteApplicationResponder(resp)
-	if err != nil {
-		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure responding to request")
-	}
-
-	return result, nil
+	return autorest.Respond(
+		resp,
+		c.client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusNotFound),
+		autorest.ByClosing())
 }
 
 func (c *AppClient) AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (result PasswordCredentialResult, err error) {
@@ -137,24 +135,23 @@ func (c *AppClient) AddApplicationPassword(ctx context.Context, applicationObjec
 	return result, nil
 }
 
-func (c *AppClient) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (result autorest.Response, err error) {
+func (c *AppClient) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (err error) {
 	req, err := c.removePasswordPreparer(ctx, applicationObjectID, keyID)
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", nil, "Failure preparing request")
+		return autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", nil, "Failure preparing request")
 	}
 
 	resp, err := c.removePasswordSender(req)
 	if err != nil {
-		result = autorest.Response{Response: resp}
-		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure sending request")
+		return autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure sending request")
 	}
 
-	result, err = c.removePasswordResponder(resp)
+	_, err = c.removePasswordResponder(resp)
 	if err != nil {
-		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure responding to request")
+		return autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure responding to request")
 	}
 
-	return result, nil
+	return nil
 }
 
 func (c AppClient) getApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {
@@ -320,19 +317,6 @@ func (c AppClient) deleteApplicationPreparer(ctx context.Context, applicationObj
 func (c AppClient) deleteApplicationSender(req *http.Request) (*http.Response, error) {
 	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(c.client.RetryAttempts, c.client.RetryDuration, autorest.StatusCodesForRetry...))
 	return autorest.SendWithSender(c.client, req, sd...)
-}
-
-func (c AppClient) deleteApplicationResponder(resp *http.Response) (result autorest.Response, err error) {
-	err = autorest.Respond(
-		resp,
-		c.client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
-		autorest.ByUnmarshallingJSON(&result),
-		autorest.ByClosing())
-	result = autorest.Response{
-		Response: resp,
-	}
-	return result, err
 }
 
 func (c AppClient) AddGroupMember(ctx context.Context, groupObjectID string, memberObjectID string) error {

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -52,46 +52,45 @@ func (c *AppClient) AddToUserAgent(extension string) error {
 func (c *AppClient) GetApplication(ctx context.Context, applicationObjectID string) (result ApplicationResult, err error) {
 	req, err := c.getApplicationPreparer(ctx, applicationObjectID)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "GetApplication", nil, "Failure preparing request")
-		return
+		return result, autorest.NewErrorWithError(err, "provider", "GetApplication", nil, "Failure preparing request")
 	}
 
 	resp, err := c.getApplicationSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure sending request")
-		return
+		result = ApplicationResult{
+			Response: autorest.Response{Response: resp},
+		}
+		return result, autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure sending request")
 	}
 
 	result, err = c.getApplicationResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure responding to request")
+		return result, autorest.NewErrorWithError(err, "provider", "GetApplication", resp, "Failure responding to request")
 	}
 
-	return
+	return result, nil
 }
 
 // CreateApplication create a new Azure application object.
 func (c *AppClient) CreateApplication(ctx context.Context, displayName string) (result ApplicationResult, err error) {
 	req, err := c.createApplicationPreparer(ctx, displayName)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", nil, "Failure preparing request")
-		return
+		return result, autorest.NewErrorWithError(err, "provider", "CreateApplication", nil, "Failure preparing request")
 	}
 
 	resp, err := c.createApplicationSender(req)
 	if err != nil {
 		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure sending request")
-		return
+		return result, autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure sending request")
 	}
 
 	result, err = c.createApplicationResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure responding to request")
+		return result, autorest.NewErrorWithError(err, "provider", "CreateApplication", resp, "Failure responding to request")
+
 	}
 
-	return
+	return result, nil
 }
 
 // DeleteApplication deletes an Azure application object.
@@ -99,67 +98,63 @@ func (c *AppClient) CreateApplication(ctx context.Context, displayName string) (
 func (c *AppClient) DeleteApplication(ctx context.Context, applicationObjectID string) (result autorest.Response, err error) {
 	req, err := c.deleteApplicationPreparer(ctx, applicationObjectID)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", nil, "Failure preparing request")
-		return
+		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", nil, "Failure preparing request")
 	}
 
 	resp, err := c.deleteApplicationSender(req)
 	if err != nil {
-		result.Response = resp
-		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
-		return
+		result = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
 	}
 
 	result, err = c.deleteApplicationResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure responding to request")
+		return result, autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure responding to request")
 	}
 
-	return
+	return result, nil
 }
 
 func (c *AppClient) AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (result PasswordCredentialResult, err error) {
 	req, err := c.addPasswordPreparer(ctx, applicationObjectID, displayName, endDateTime)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", nil, "Failure preparing request")
-		return
+		return PasswordCredentialResult{}, autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", nil, "Failure preparing request")
 	}
 
 	resp, err := c.addPasswordSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure sending request")
-		return
+		result = PasswordCredentialResult{
+			Response: autorest.Response{Response: resp},
+		}
+		return result, autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure sending request")
 	}
 
 	result, err = c.addPasswordResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure responding to request")
+		return result, autorest.NewErrorWithError(err, "provider", "AddApplicationPassword", resp, "Failure responding to request")
 	}
 
-	return
+	return result, nil
 }
 
 func (c *AppClient) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (result autorest.Response, err error) {
 	req, err := c.removePasswordPreparer(ctx, applicationObjectID, keyID)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", nil, "Failure preparing request")
-		return
+		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", nil, "Failure preparing request")
 	}
 
 	resp, err := c.removePasswordSender(req)
 	if err != nil {
-		result.Response = resp
-		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure sending request")
-		return
+		result = autorest.Response{Response: resp}
+		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure sending request")
 	}
 
 	result, err = c.removePasswordResponder(resp)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure responding to request")
+		return result, autorest.NewErrorWithError(err, "provider", "RemoveApplicationPassword", resp, "Failure responding to request")
 	}
 
-	return
+	return result, nil
 }
 
 func (c AppClient) getApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {
@@ -228,8 +223,10 @@ func (c AppClient) addPasswordResponder(resp *http.Response) (result PasswordCre
 		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
-	return
+	result = PasswordCredentialResult{
+		Response: autorest.Response{Response: resp},
+	}
+	return result, err
 }
 
 func (c AppClient) removePasswordPreparer(ctx context.Context, applicationObjectID string, keyID string) (*http.Request, error) {
@@ -265,8 +262,10 @@ func (c AppClient) removePasswordResponder(resp *http.Response) (result autorest
 		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = resp
-	return
+	result = autorest.Response{
+		Response: resp,
+	}
+	return result, err
 }
 
 func (c AppClient) createApplicationPreparer(ctx context.Context, displayName string) (*http.Request, error) {
@@ -298,8 +297,10 @@ func (c AppClient) createApplicationResponder(resp *http.Response) (result Appli
 		azure.WithErrorUnlessStatusCode(http.StatusCreated),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = autorest.Response{Response: resp}
-	return
+	result = ApplicationResult{
+		Response: autorest.Response{Response: resp},
+	}
+	return result, nil
 }
 
 func (c AppClient) deleteApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {
@@ -328,8 +329,10 @@ func (c AppClient) deleteApplicationResponder(resp *http.Response) (result autor
 		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
-	result.Response = resp
-	return
+	result = autorest.Response{
+		Response: resp,
+	}
+	return result, err
 }
 
 func (c AppClient) AddGroupMember(ctx context.Context, groupObjectID string, memberObjectID string) error {

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -106,11 +106,12 @@ func (c *AppClient) DeleteApplication(ctx context.Context, applicationObjectID s
 		return autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure sending request")
 	}
 
-	return autorest.Respond(
+	err = autorest.Respond(
 		resp,
 		c.client.ByInspecting(),
 		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusNotFound),
 		autorest.ByClosing())
+	return autorest.NewErrorWithError(err, "provider", "DeleteApplication", resp, "Failure responding to request")
 }
 
 func (c *AppClient) AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime date.Time) (result PasswordCredentialResult, err error) {

--- a/client.go
+++ b/client.go
@@ -110,7 +110,8 @@ func (c *client) addAppPassword(ctx context.Context, appObjID string, expiresIn 
 
 // deleteAppPassword removes a password, if present, from an App's credentials list.
 func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) error {
-	if _, err := c.provider.RemoveApplicationPassword(ctx, appObjID, keyID); err != nil {
+	err := c.provider.RemoveApplicationPassword(ctx, appObjID, keyID)
+	if err != nil {
 		if strings.Contains(err.Error(), "No password credential found with keyId") {
 			return nil
 		}
@@ -122,14 +123,7 @@ func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) 
 
 // deleteApp deletes an Azure application.
 func (c *client) deleteApp(ctx context.Context, appObjectID string) error {
-	resp, err := c.provider.DeleteApplication(ctx, appObjectID)
-
-	// Don't consider it an error if the object wasn't present
-	if err != nil && resp.Response != nil && resp.StatusCode == 404 {
-		return nil
-	}
-
-	return err
+	return c.provider.DeleteApplication(ctx, appObjectID)
 }
 
 // assignRoles assigns Azure roles to a service principal.

--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/hashicorp/errwrap"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
@@ -86,7 +85,7 @@ func (c *client) createSP(
 	})
 
 	if err != nil {
-		return "", "", errwrap.Wrapf("error creating service principal: {{err}}", err)
+		return "", "", fmt.Errorf("error creating service principal: %w", err)
 	}
 
 	result := resultRaw.(idPass)
@@ -102,7 +101,7 @@ func (c *client) addAppPassword(ctx context.Context, appObjID string, expiresIn 
 		if strings.Contains(err.Error(), "size of the object has exceeded its limit") {
 			err = errors.New("maximum number of Application passwords reached")
 		}
-		return "", "", errwrap.Wrapf("error updating credentials: {{err}}", err)
+		return "", "", fmt.Errorf("error updating credentials: %w", err)
 	}
 
 	return to.String(resp.KeyID), to.String(resp.SecretText), nil
@@ -115,7 +114,7 @@ func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) 
 		if strings.Contains(err.Error(), "No password credential found with keyId") {
 			return nil
 		}
-		return errwrap.Wrapf("error removing credentials: {{err}}", err)
+		return fmt.Errorf("error removing credentials: %w", err)
 	}
 
 	return nil
@@ -154,7 +153,7 @@ func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRol
 		})
 
 		if err != nil {
-			return nil, errwrap.Wrapf("error while assigning roles: {{err}}", err)
+			return nil, fmt.Errorf("error while assigning roles: %w", err)
 		}
 
 		ids = append(ids, resultRaw.(string))
@@ -172,7 +171,7 @@ func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
 
 	for _, id := range roleIDs {
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctx, id); err != nil {
-			merr = multierror.Append(merr, errwrap.Wrapf("error unassigning role: {{err}}", err))
+			merr = multierror.Append(merr, fmt.Errorf("error unassigning role: %w", err))
 		}
 	}
 
@@ -194,7 +193,7 @@ func (c *client) addGroupMemberships(ctx context.Context, spID string, groups []
 		})
 
 		if err != nil {
-			return errwrap.Wrapf("error while adding group membership: {{err}}", err)
+			return fmt.Errorf("error while adding group membership: %w", err)
 		}
 	}
 
@@ -210,7 +209,7 @@ func (c *client) removeGroupMemberships(ctx context.Context, servicePrincipalObj
 
 	for _, id := range groupIDs {
 		if err := c.provider.RemoveGroupMember(ctx, servicePrincipalObjectID, id); err != nil {
-			merr = multierror.Append(merr, errwrap.Wrapf("error removing group membership: {{err}}", err))
+			merr = multierror.Append(merr, fmt.Errorf("error removing group membership: %w", err))
 		}
 	}
 
@@ -286,7 +285,7 @@ func (b *azureSecretBackend) getClientSettings(ctx context.Context, config *azur
 
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		return nil, errwrap.Wrapf("error loading plugin environment: {{err}}", err)
+		return nil, fmt.Errorf("error loading plugin environment: %w", err)
 	}
 	settings.PluginEnv = pluginEnv
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/frankban/quicktest v1.10.0 // indirect
 	github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31
-	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -114,7 +113,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 		Expiration: time.Now().Add(maxWALAge),
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("error writing WAL: {{err}}", err)
+		return nil, fmt.Errorf("error writing WAL: %w", err)
 	}
 
 	// Create a service principal associated with the new App
@@ -136,7 +135,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 
 	// SP is fully created so delete the WAL
 	if err := framework.DeleteWAL(ctx, s, walID); err != nil {
-		return nil, errwrap.Wrapf("error deleting WAL: {{err}}", err)
+		return nil, fmt.Errorf("error deleting WAL: %w", err)
 	}
 
 	data := map[string]interface{}{
@@ -237,7 +236,7 @@ func (b *azureSecretBackend) spRevoke(ctx context.Context, req *logical.Request,
 
 	c, err := b.getClient(ctx, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("error during revoke: {{err}}", err)
+		return nil, fmt.Errorf("error during revoke: %w", err)
 	}
 
 	// unassigning roles is effectively a garbage collection operation. Errors will be noted but won't fail the
@@ -268,7 +267,7 @@ func (b *azureSecretBackend) staticSPRevoke(ctx context.Context, req *logical.Re
 
 	c, err := b.getClient(ctx, req.Storage)
 	if err != nil {
-		return nil, errwrap.Wrapf("error during revoke: {{err}}", err)
+		return nil, fmt.Errorf("error during revoke: %w", err)
 	}
 
 	keyIDRaw, ok := req.Secret.InternalData["key_id"]

--- a/provider.go
+++ b/provider.go
@@ -166,7 +166,7 @@ func (p *provider) GetApplication(ctx context.Context, applicationObjectID strin
 
 // DeleteApplication deletes an Azure application object.
 // This will in turn remove the service principal (but not the role assignments).
-func (p *provider) DeleteApplication(ctx context.Context, applicationObjectID string) (autorest.Response, error) {
+func (p *provider) DeleteApplication(ctx context.Context, applicationObjectID string) error {
 	return p.appClient.DeleteApplication(ctx, applicationObjectID)
 }
 
@@ -174,7 +174,7 @@ func (p *provider) AddApplicationPassword(ctx context.Context, applicationObject
 	return p.appClient.AddApplicationPassword(ctx, applicationObjectID, displayName, endDateTime)
 }
 
-func (p *provider) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (result autorest.Response, err error) {
+func (p *provider) RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) (err error) {
 	return p.appClient.RemoveApplicationPassword(ctx, applicationObjectID, keyID)
 }
 

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
@@ -34,7 +33,7 @@ func newMockProvider() api.AzureProvider {
 }
 
 // ListRoles returns a single fake role based on the inbound filter
-func (m *mockProvider) ListRoleDefinitions(_ context.Context, _ string, filter string) (result []authorization.RoleDefinition, err error) {
+func (m *mockProvider) ListRoleDefinitions(_ context.Context, _ string, filter string) ([]authorization.RoleDefinition, error) {
 	reRoleName := regexp.MustCompile("roleName eq '(.*)'")
 
 	match := reRoleName.FindAllStringSubmatch(filter, -1)
@@ -71,7 +70,7 @@ func (m *mockProvider) ListRoleDefinitions(_ context.Context, _ string, filter s
 
 // GetRoleByID will returns a fake role definition from the povided ID
 // Assumes an ID format of: .*FAKE_ROLE-{rolename}
-func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (result authorization.RoleDefinition, err error) {
+func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (authorization.RoleDefinition, error) {
 	d := authorization.RoleDefinition{}
 	s := strings.Split(roleID, "FAKE_ROLE-")
 	if len(s) > 1 {
@@ -84,7 +83,7 @@ func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (
 	return d, nil
 }
 
-func (m *mockProvider) CreateServicePrincipal(_ context.Context, _ string, _ time.Time, _ time.Time) (string, string, error) {
+func (m *mockProvider) CreateServicePrincipal(_ context.Context, _ string, _ time.Time, _ time.Time) (spID string, password string, err error) {
 	id := generateUUID()
 	pass := generateUUID()
 	return id, pass, nil
@@ -119,7 +118,7 @@ func (m *mockProvider) DeleteApplication(_ context.Context, applicationObjectID 
 	return nil
 }
 
-func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, displayName string, endDateTime date.Time) (result api.PasswordCredentialResult, err error) {
+func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, displayName string, endDateTime date.Time) (api.PasswordCredentialResult, error) {
 	keyID := generateUUID()
 	cred := api.PasswordCredential{
 		DisplayName: to.StringPtr(displayName),
@@ -138,7 +137,7 @@ func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, displ
 	}, nil
 }
 
-func (m *mockProvider) RemoveApplicationPassword(_ context.Context, _ string, keyID string) (err error) {
+func (m *mockProvider) RemoveApplicationPassword(_ context.Context, _ string, keyID string) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -156,31 +155,23 @@ func (m *mockProvider) passwordExists(s string) bool {
 	return ok
 }
 
-func (m *mockProvider) VMGet(_ context.Context, _ string, _ string, _ compute.InstanceViewTypes) (result compute.VirtualMachine, err error) {
-	return compute.VirtualMachine{}, nil
-}
-
-func (m *mockProvider) VMUpdate(_ context.Context, _ string, _ string, _ compute.VirtualMachineUpdate) (result compute.VirtualMachinesUpdateFuture, err error) {
-	return compute.VirtualMachinesUpdateFuture{}, nil
-}
-
 func (m *mockProvider) CreateRoleAssignment(_ context.Context, _ string, _ string, _ authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
 	return authorization.RoleAssignment{
 		ID: to.StringPtr(generateUUID()),
 	}, nil
 }
 
-func (m *mockProvider) DeleteRoleAssignmentByID(_ context.Context, _ string) (result authorization.RoleAssignment, err error) {
+func (m *mockProvider) DeleteRoleAssignmentByID(_ context.Context, _ string) (authorization.RoleAssignment, error) {
 	return authorization.RoleAssignment{}, nil
 }
 
 // AddGroupMember adds a member to a AAD Group.
-func (m *mockProvider) AddGroupMember(_ context.Context, _ string, _ string) (err error) {
+func (m *mockProvider) AddGroupMember(_ context.Context, _ string, _ string) error {
 	return nil
 }
 
 // RemoveGroupMember removes a member from a AAD Group.
-func (m *mockProvider) RemoveGroupMember(_ context.Context, _ string, _ string) (err error) {
+func (m *mockProvider) RemoveGroupMember(_ context.Context, _ string, _ string) error {
 	return nil
 }
 
@@ -198,7 +189,7 @@ func (m *mockProvider) GetGroup(_ context.Context, objectID string) (api.Group, 
 }
 
 // ListGroups gets list of groups for the current tenant.
-func (m *mockProvider) ListGroups(_ context.Context, filter string) (result []api.Group, err error) {
+func (m *mockProvider) ListGroups(_ context.Context, filter string) ([]api.Group, error) {
 	reGroupName := regexp.MustCompile("displayName eq '(.*)'")
 
 	match := reGroupName.FindAllStringSubmatch(filter, -1)
@@ -245,7 +236,7 @@ func newErrMockProvider() api.AzureProvider {
 }
 
 // CreateRoleAssignment for the errMockProvider intentionally fails
-func (e *errMockProvider) CreateRoleAssignment(ctx context.Context, scope string, roleAssignmentName string, parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
+func (e *errMockProvider) CreateRoleAssignment(_ context.Context, _ string, _ string, _ authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
 	return authorization.RoleAssignment{}, errors.New("PrincipalNotFound")
 }
 
@@ -253,7 +244,7 @@ func (e *errMockProvider) CreateRoleAssignment(ctx context.Context, scope string
 // key is found, unlike mockProvider which returns the same application object
 // id each time. Existing tests depend on the mockProvider behavior, which is
 // why errMockProvider has it's own version.
-func (e *errMockProvider) GetApplication(ctx context.Context, applicationObjectID string) (api.ApplicationResult, error) {
+func (e *errMockProvider) GetApplication(_ context.Context, applicationObjectID string) (api.ApplicationResult, error) {
 	for s := range e.applications {
 		if s == applicationObjectID {
 			return api.ApplicationResult{

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
@@ -115,9 +114,9 @@ func (m *mockProvider) GetApplication(_ context.Context, _ string) (api.Applicat
 	}, nil
 }
 
-func (m *mockProvider) DeleteApplication(_ context.Context, applicationObjectID string) (autorest.Response, error) {
+func (m *mockProvider) DeleteApplication(_ context.Context, applicationObjectID string) error {
 	delete(m.applications, applicationObjectID)
-	return autorest.Response{}, nil
+	return nil
 }
 
 func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, displayName string, endDateTime date.Time) (result api.PasswordCredentialResult, err error) {
@@ -139,13 +138,13 @@ func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, displ
 	}, nil
 }
 
-func (m *mockProvider) RemoveApplicationPassword(_ context.Context, _ string, keyID string) (result autorest.Response, err error) {
+func (m *mockProvider) RemoveApplicationPassword(_ context.Context, _ string, keyID string) (err error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	delete(m.passwords, keyID)
 
-	return autorest.Response{}, nil
+	return nil
 }
 
 func (m *mockProvider) appExists(s string) bool {


### PR DESCRIPTION
# Overview
A bunch of little code cleanup tasks including:
* Removed bare returns
* Removed unused return values
* Removed errwrap
* Small readability improvements

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  No docs needed - this is just code cleanup
- [x] Backwards compatible
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
<details>
<summary>MS Graph</summary>

```
$ VAULT_ACC=1 richgo test -v -run TestCredentialInteg_msgraph
START| CredentialInteg_msgraph
START|   CredentialInteg_msgraph/service_principals
     | === PAUSE TestCredentialInteg_msgraph/service_principals
     | === CONT  TestCredentialInteg_msgraph/service_principals
PASS | CredentialInteg_msgraph (0.00s)
PASS |   CredentialInteg_msgraph/service_principals (20.26s)
PASS
PASS | github.com/hashicorp/vault-plugin-secrets-azure 20.540s  
```
</details>

<details>
<summary>AAD</summary>

```
$ VAULT_ACC=1 richgo test -v -run TestCredentialInteg_aad
START| CredentialInteg_aad
START|   CredentialInteg_aad/service_principals
     | === PAUSE TestCredentialInteg_aad/service_principals
START|   CredentialInteg_aad/static_service_principals
     | === PAUSE TestCredentialInteg_aad/static_service_principals
     | === CONT  TestCredentialInteg_aad/service_principals
     | === CONT  TestCredentialInteg_aad/static_service_principals
PASS | CredentialInteg_aad (0.00s)
PASS |   CredentialInteg_aad/static_service_principals (50.83s)
PASS |   CredentialInteg_aad/service_principals (53.29s)
PASS
PASS | github.com/hashicorp/vault-plugin-secrets-azure 53.530s
```
</details>