### PR TITLE
Fix panic caused by shallowed error in create application

### DIFF
--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -292,7 +292,7 @@ func (c AppClient) createApplicationResponder(resp *http.Response) (result Appli
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
-	return result, nil
+	return result, err
 }
 
 func (c AppClient) deleteApplicationPreparer(ctx context.Context, applicationObjectID string) (*http.Request, error) {


### PR DESCRIPTION
An error is being shallowed when creating application which can cause a panic as the plugin attempts to use nil pointers. Since no errors are being reported, the plugin assumes the operation was successful and attempts to use values in the response.