### PR TITLE
Fix segfault when config is nil

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -195,15 +195,15 @@ func (b *azureSecretBackend) getClient(ctx context.Context, s logical.Storage) (
 			config = new(azureConfig)
 		}
 
-		if config == nil {
-			return nil, fmt.Errorf("config is nil")
-		}
-
 		settings, err := b.getClientSettings(ctx, config)
 		if err != nil {
 			return nil, err
 		}
 		b.settings = settings
+	}
+
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
 	}
 
 	passwords := api.Passwords{

--- a/backend.go
+++ b/backend.go
@@ -190,13 +190,13 @@ func (b *azureSecretBackend) getClient(ctx context.Context, s logical.Storage) (
 		return nil, err
 	}
 
-	if config == nil {
-		return nil, fmt.Errorf("config is nil")
-	}
-
 	if b.settings == nil {
 		if config == nil {
 			config = new(azureConfig)
+		}
+
+		if config == nil {
+			return nil, fmt.Errorf("config is nil")
 		}
 
 		settings, err := b.getClientSettings(ctx, config)

--- a/backend.go
+++ b/backend.go
@@ -87,6 +87,8 @@ func (b *azureSecretBackend) periodicFunc(ctx context.Context, sys *logical.Requ
 		return err
 	}
 
+	// Config can be nil if deleted or when the engine is enabled
+	// but not yet configured.
 	if config == nil {
 		return nil
 	}
@@ -186,6 +188,10 @@ func (b *azureSecretBackend) getClient(ctx context.Context, s logical.Storage) (
 	config, err := b.getConfig(ctx, s)
 	if err != nil {
 		return nil, err
+	}
+
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
 	}
 
 	if b.settings == nil {

--- a/backend.go
+++ b/backend.go
@@ -87,6 +87,10 @@ func (b *azureSecretBackend) periodicFunc(ctx context.Context, sys *logical.Requ
 		return err
 	}
 
+	if config == nil {
+		return nil
+	}
+
 	// Password should be at least a minute old before we process it
 	if config.NewClientSecret == "" || (time.Since(config.NewClientSecretCreated) < time.Minute) {
 		return nil

--- a/backend_test.go
+++ b/backend_test.go
@@ -61,3 +61,34 @@ func getTestBackend(t *testing.T, initConfig bool) (*azureSecretBackend, logical
 
 	return b, config.StorageView
 }
+
+func TestPeriodicFuncNilConfig(t *testing.T) {
+	b := backend()
+
+	config := &logical.BackendConfig{
+		Logger: logging.NewVaultLogger(log.Trace),
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: defaultLeaseTTLHr,
+			MaxLeaseTTLVal:     maxLeaseTTLHr,
+		},
+		StorageView: &logical.InmemStorage{},
+	}
+	err := b.Setup(context.Background(), config)
+	if err != nil {
+		t.Fatalf("unable to create backend: %v", err)
+	}
+
+	b.settings = new(clientSettings)
+	mockProvider := newMockProvider()
+	b.getProvider = func(s *clientSettings, usMsGraphApi bool, p api.Passwords) (api.AzureProvider, error) {
+		return mockProvider, nil
+	}
+
+	err = b.periodicFunc(context.Background(), &logical.Request{
+		Storage: config.StorageView,
+	})
+
+	if err != nil {
+		t.Fatalf("periodicFunc error'd, it should not have: %v", err)
+	}
+}

--- a/backend_test.go
+++ b/backend_test.go
@@ -89,6 +89,6 @@ func TestPeriodicFuncNilConfig(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatalf("periodicFunc error'd, it should not have: %v", err)
+		t.Fatalf("periodicFunc error not nil, it should have been: %v", err)
 	}
 }

--- a/path_roles.go
+++ b/path_roles.go
@@ -129,6 +129,10 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+
 	client, err := b.getClient(ctx, req.Storage)
 	if err != nil {
 		return nil, err
@@ -292,6 +296,10 @@ func (b *azureSecretBackend) pathRoleRead(ctx context.Context, req *logical.Requ
 	config, err := b.getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
+	}
+
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
 	}
 
 	r, err := getRole(ctx, name, req.Storage)

--- a/path_rotate_root.go
+++ b/path_rotate_root.go
@@ -34,6 +34,10 @@ func (b *azureSecretBackend) pathRotateRoot(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
+	if config == nil {
+		return nil, fmt.Errorf("config is nil")
+	}
+
 	expDur := config.RootPasswordTTL
 	if expDur == 0 {
 		expDur = defaultRootPasswordTTL


### PR DESCRIPTION
If `config` is nil (backend is enabled but not yet configured), the periodic function will fail because it does not check if the config is nil. Added a guard and a test to cover this case.