### PR TITLE
Update authorization to 2018-01-01 preview

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 )

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	multierror "github.com/hashicorp/go-multierror"
@@ -138,7 +138,7 @@ func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRol
 		resultRaw, err := retry(ctx, func() (interface{}, bool, error) {
 			ra, err := c.provider.CreateRoleAssignment(ctx, role.Scope, assignmentID,
 				authorization.RoleAssignmentCreateParameters{
-					Properties: &authorization.RoleAssignmentProperties{
+					RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 						RoleDefinitionID: &role.RoleID,
 						PrincipalID:      &spID,
 					},

--- a/mock_provider_test.go
+++ b/mock_provider_test.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	authorization "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	authorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	gomock "github.com/golang/mock/gomock"
 	api "github.com/hashicorp/vault-plugin-secrets-azure/api"
 )

--- a/path_roles.go
+++ b/path_roles.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
 	"github.com/hashicorp/vault/sdk/framework"

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -565,7 +565,7 @@ func TestCredentialInteg_aad(t *testing.T) {
 		roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
 		assertErrorIsNil(t, err)
 
-		defID := *ra.Properties.RoleDefinitionID
+		defID := *ra.ID
 		found := false
 		for _, def := range roleDefs {
 			if *def.ID == defID && *def.RoleName == "Reader" {
@@ -826,7 +826,7 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 		roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
 		assertErrorIsNil(t, err)
 
-		defID := *ra.Properties.RoleDefinitionID
+		defID := *ra.ID
 		found := false
 		for _, def := range roleDefs {
 			if *def.ID == defID && *def.RoleName == "Reader" {

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -497,9 +497,19 @@ func TestCredentialInteg_aad(t *testing.T) {
 	t.Run("service principals", func(t *testing.T) {
 		t.Parallel()
 
+		skipIfMissingEnvVars(t,
+			"AZURE_SUBSCRIPTION_ID",
+			"AZURE_CLIENT_ID",
+			"AZURE_CLIENT_SECRET",
+			"AZURE_TENANT_ID",
+		)
+
 		b := backend()
 		s := new(logical.InmemStorage)
 		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
 
 		config := &logical.BackendConfig{
 			Logger: logging.NewVaultLogger(log.Trace),
@@ -511,6 +521,22 @@ func TestCredentialInteg_aad(t *testing.T) {
 		}
 		err := b.Setup(context.Background(), config)
 		assertErrorIsNil(t, err)
+
+		configData := map[string]interface{}{
+			"subscription_id":         subscriptionID,
+			"client_id":               clientID,
+			"client_secret":           clientSecret,
+			"tenant_id":               tenantID,
+			"use_microsoft_graph_api": false,
+		}
+
+		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "config",
+			Data:      configData,
+			Storage:   s,
+		})
+		assertRespNoError(t, configResp, err)
 
 		// Add a Vault role that will provide creds with Azure "Reader" permissions
 		// Resources groups "vault-azure-secrets-test1" and "vault-azure-secrets-test2"
@@ -565,7 +591,7 @@ func TestCredentialInteg_aad(t *testing.T) {
 		roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
 		assertErrorIsNil(t, err)
 
-		defID := *ra.ID
+		defID := *ra.RoleAssignmentPropertiesWithScope.RoleDefinitionID
 		found := false
 		for _, def := range roleDefs {
 			if *def.ID == defID && *def.RoleName == "Reader" {
@@ -598,8 +624,19 @@ func TestCredentialInteg_aad(t *testing.T) {
 	t.Run("static service principals", func(t *testing.T) {
 		t.Parallel()
 
+		skipIfMissingEnvVars(t,
+			"AZURE_SUBSCRIPTION_ID",
+			"AZURE_CLIENT_ID",
+			"AZURE_CLIENT_SECRET",
+			"AZURE_TENANT_ID",
+		)
+
 		b := backend()
 		s := new(logical.InmemStorage)
+		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
 
 		config := &logical.BackendConfig{
 			Logger: logging.NewVaultLogger(log.Trace),
@@ -612,8 +649,21 @@ func TestCredentialInteg_aad(t *testing.T) {
 		err := b.Setup(context.Background(), config)
 		assertErrorIsNil(t, err)
 
-		// Add a Vault role that will provide creds with Azure "Reader" permissions
-		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		configData := map[string]interface{}{
+			"subscription_id":         subscriptionID,
+			"client_id":               clientID,
+			"client_secret":           clientSecret,
+			"tenant_id":               tenantID,
+			"use_microsoft_graph_api": false,
+		}
+
+		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "config",
+			Data:      configData,
+			Storage:   s,
+		})
+		assertRespNoError(t, configResp, err)
 
 		rolename := "static_test_role"
 		role := map[string]interface{}{
@@ -781,7 +831,7 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 		roleData := map[string]interface{}{
 			"azure_roles": fmt.Sprintf(`[
 			{
-				"role_name": "Reader",
+				"role_name": "Storage Blob Data Owner",
 				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
 			},
 			{
@@ -826,17 +876,17 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 		roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
 		assertErrorIsNil(t, err)
 
-		defID := *ra.ID
+		defID := *ra.RoleAssignmentPropertiesWithScope.RoleDefinitionID
 		found := false
 		for _, def := range roleDefs {
-			if *def.ID == defID && *def.RoleName == "Reader" {
+			if *def.ID == defID && *def.RoleName == "Storage Blob Data Owner" {
 				found = true
 				break
 			}
 		}
 
 		if !found {
-			t.Fatal("'Reader' role assignment not found")
+			t.Fatal("'Storage Blob Data Owner' role assignment not found")
 		}
 
 		// Serialize and deserialize the secret to remove typing, as will really happen.

--- a/provider.go
+++ b/provider.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"


### PR DESCRIPTION
I'm updating the authorization packages to 2018-01-01 preview to support roles that use data actions in Azure. The existing authorization package points to 2015-07-01, which does not support them.

Fixes #82.