### PR TITLE
Fix bats based MS Graph acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ You can also specify a `TESTARGS` variable to filter tests like so:
 $ make test TESTARGS='--run=TestConfig'
 ```
 
+#### Acceptance Tests
+
 Acceptance tests requires Azure access, and the following to be installed:
 - [Docker](https://docs.docker.com/get-docker/)
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
@@ -136,6 +138,13 @@ for more information.
 $ make test-acceptance AZURE_TENANT_ID=<your_tenant_id>
 ```
 
+Setting `WITH_DEV_PLUGIN=1` will first build the local plugin, and automatically register
+it with the test Vault instance.
+
+```sh
+$ make test-acceptance AZURE_TENANT_ID=<your_tenant_id> WITH_DEV_PLUGIN=1
+```
+
 Running tests against Vault Enterprise requires a valid license, and specifying an enterprise docker image:
 
 ```sh
@@ -143,3 +152,7 @@ $ make test-acceptance AZURE_TENANT_ID=<your_tenant_id> \
   VAULT_LICENSE=........ \
   VAULT_IMAGE=hashicorp/vault-enterprise:latest
 ```
+
+The `test-acceptance` make target also accepts the following environment based directives:
+
+* `TESTS_FILTER`: a regex of Bats tests to run, useful when you only want to run a subset of the tests.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,10 +61,12 @@ IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory
 DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
+if [ -d "${DEV_PLATFORM}" ]; then
+    for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
+        cp ${F} bin/
+        cp ${F} ${MAIN_GOPATH}/bin/
+    done
+fi
 
 if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
     # Zip and copy to the dist dir

--- a/tests/acceptance/basic.bats
+++ b/tests/acceptance/basic.bats
@@ -6,7 +6,7 @@ load common.sh
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PLUGIN_NAME="${REPO_ROOT##*/}"
-VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.9.0}"
+VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.9.3}"
 CONTAINER_NAME=''
 VAULT_TOKEN='root'
 

--- a/tests/acceptance/basic.bats
+++ b/tests/acceptance/basic.bats
@@ -36,10 +36,9 @@ if [[ -z "${AZURE_TENANT_ID}" ]]; then
     exit 1
 fi
 
-
 if [[ -n "${WITH_DEV_PLUGIN}" ]]; then
     PLUGIN=${REPO_ROOT}/pkg/linux_amd64/${PLUGIN_NAME}
-    PLUGIN_SHA256="$(sha256sum ${PLUGIN} | cut -d ' ' -f 1)"
+    PLUGIN_SHA256="$(sha256sum ${PLUGIN} | cut -d ' ' -f 1)" || exit 1
 fi
 
 setup(){

--- a/tests/acceptance/basic.bats
+++ b/tests/acceptance/basic.bats
@@ -159,7 +159,6 @@ teardown(){
     sleep 30
 
     local roles=('Reader' 'Storage Blob Data Owner')
-    local roles=('Reader' 'Storage Blob Data Owner')
     for ((i=0; i < ${#roles[@]}; i++)); do
         testAzureSecret "${roles[$i]}" ${subscription_id} ${resource_group_name} "role-${i}" ${CONFIG_DIR} ${ENGINE_NAME}
     done

--- a/tests/acceptance/basic.bats
+++ b/tests/acceptance/basic.bats
@@ -1,23 +1,29 @@
 #!/usr/bin/env bats
 
+load common.sh
+
 # based off of the "Vault Ecosystem - Testing Best Practices" Confluence page.
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PLUGIN_NAME="${REPO_ROOT##*/}"
-VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.9.0-rc1}"
+VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.9.0}"
 CONTAINER_NAME=''
 VAULT_TOKEN='root'
 
 TESTS_OUT_DIR="$(mktemp -d /tmp/${PLUGIN_NAME}.XXXXXXXXX)"
-TESTS_OUT_FILE="${TESTS_OUT_DIR}/output.log"
+TESTS_OUT_FILE="${TESTS_OUT_FILE:-${TESTS_OUT_DIR}/output.log}"
 
 PLUGIN_TYPE=''
 case ${PLUGIN_NAME} in
   *-secrets-*)
     PLUGIN_TYPE='secret'
+    # short name e.g. `azure`
+    ENGINE_NAME="${PLUGIN_NAME##*-secrets-}"
     ;;
   *-auth-*)
     PLUGIN_TYPE='auth'
+    # short name e.g. `azure`
+    ENGINE_NAME="${PLUGIN_NAME##*-auth-}"
     ;;
   *)
     echo "could not determine plugin type from ${PLUGIN_NAME}" >&2
@@ -32,13 +38,15 @@ fi
 
 
 if [[ -n "${WITH_DEV_PLUGIN}" ]]; then
-    PLUGIN=${REPO_ROOT}/bin/${PLUGIN_NAME}
+    PLUGIN=${REPO_ROOT}/pkg/linux_amd64/${PLUGIN_NAME}
     PLUGIN_SHA256="$(sha256sum ${PLUGIN} | cut -d ' ' -f 1)"
 fi
 
 setup(){
     { # Braces used to redirect all setup logs.
     # 1. Configure Vault.
+
+    log "SetUp"
 
     export CONFIG_DIR="$(mktemp -d ${TESTS_OUT_DIR}/test-XXXXXXX)"
     export CONTAINER_NAME="${CONFIG_DIR##*/}"
@@ -73,9 +81,9 @@ HERE
         HOST_PORT="$(docker inspect ${CONTAINER_NAME} | \
             jq -er '.[0].NetworkSettings.Ports."8200/tcp"[0].HostPort')"
 
-        if nc -z localhost ${HOST_PORT} ; then
+        if nc -z localhost ${HOST_PORT} &> /dev/null ; then
             export VAULT_ADDR="http://localhost:${HOST_PORT?}"
-            vault login ${VAULT_TOKEN?} || continue
+            vault login ${VAULT_TOKEN?} &> /dev/null || continue
             break
         fi
 
@@ -90,16 +98,21 @@ HERE
     if [[ -n "${WITH_DEV_PLUGIN}" ]]; then
         cp -a ${PLUGIN} ${CONFIG_DIR}/plugins/.
         # replace the builtin plugin with a local build
-        vault plugin register -sha256="${PLUGIN_SHA256}" ${PLUGIN_TYPE} ${PLUGIN_NAME}
-        vault plugin reload -plugin=${PLUGIN_NAME}
+        vault plugin register -sha256="${PLUGIN_SHA256}" -command=${PLUGIN_NAME} ${PLUGIN_TYPE} ${ENGINE_NAME}
+        vault plugin reload -plugin=${ENGINE_NAME}
     fi
 
+    log "SetUp successful"
     } >> $TESTS_OUT_FILE
 }
 
 teardown(){
+    log "TearDown"
+
     if [[ -n $SKIP_TEARDOWN ]]; then
-        echo "Skipping teardown"
+        logWarn "Skipping teardown"
+        logWarn "Clean up required, please run '(cd ${CONFIG_DIR}/terraform && terraform apply -destroy)'"
+        logWarn "See ${TESTS_OUT_FILE} for more details"
         return
     fi
 
@@ -115,120 +128,65 @@ teardown(){
 
     printenv | sort
 
-    pushd ${CONFIG_DIR}/terraform
-    terraform apply -destroy -input=false -auto-approve
-    popd
+    terraformDestroy ${CONFIG_DIR}
 
     rm -rf "${CONFIG_DIR}"
+
+    echo "See ${TESTS_OUT_FILE} for more details" >&2
+    log "TearDown successful"
 
     } >> $TESTS_OUT_FILE
 }
 
 @test "Azure Secrets Engine - Legacy AAD" {
-    pushd ${CONFIG_DIR}/terraform
-    terraform init && terraform apply -input=false -auto-approve -var legacy_aad_resource_access=true
-    local tf_output=$(terraform output -json | tee ${CONFIG_DIR}/tf-output.json)
-    popd
+    local tf_output_file=${CONFIG_DIR}/tf-output.json
+    terraformInitApply ${CONFIG_DIR} -var=legacy_aad_resource_access=true
+    terraformOutput ${CONFIG_DIR} > ${tf_output_file}
 
-    # TODO: remove this sleep, tests periodically fail if the credentials created during infrastructure
-    # provisioning are not considered valid by Azure. Need to find a way to poll for the creds status.
-    sleep 10
+    tfOutputLocalEnv ${tf_output_file} > ${CONFIG_DIR}/local.env
+    . ${CONFIG_DIR}/local.env
+    local >&2
 
-    local client_id="$(echo ${tf_output} | jq -er .application_id.value)"
-    local client_secret="$(echo ${tf_output} | jq -er .application_password_value.value)"
-    local subscription_id="$(echo ${tf_output} | jq -er .subscription_id.value)"
-    local resource_group_name="$(echo ${tf_output} | jq -er .resource_group_name.value)"
-    local tenant_id="$(echo ${tf_output} | jq -er .tenant_id.value)"
-
-    vault secrets enable azure
-
-    vault write azure/config \
+    vault secrets enable ${ENGINE_NAME}
+    vault write "${ENGINE_NAME}/config" \
+        use_microsoft_graph_api=false \
         subscription_id=${subscription_id} \
         tenant_id="${tenant_id}" \
         client_id="${client_id}" \
         client_secret="${client_secret}"
 
-    local ttl=10
-    vault write azure/roles/my-role ttl="${ttl}" azure_roles=-<<EOF
-[
-    {
-        "role_name": "Reader",
-        "scope":  "/subscriptions/${subscription_id}/resourceGroups/${resource_group_name}"
-    }
-]
-EOF
-    local secret="$(vault read azure/creds/my-role -format=json)"
-    local sp_id="$(echo ${secret} | jq -er .data.client_id)"
-    local sp="$(az ad sp show --id "${sp_id}")"
-    echo ${secret} | jq
-    echo ${sp} | jq
+    # Azure API access provisioning seems to be delayed for whatever reason, so sleep a bit.
+    sleep 30
 
-    sleep ${ttl}
-    local tries=0
-    # wait for the service principal to expire and be removed by Vault - adds a 5 second buffer.
-    until ! az ad sp show --id "${sp_id}" > /dev/null
-    do
-        if [[ "${tries}" -ge 10 ]]; then
-            echo "vault failed to remove service principal ${sp_id}, ttl=${ttl}" >&2
-            exit 1
-        fi
-        ((++tries))
-        sleep .5
+    local roles=('Reader' 'Storage Blob Data Owner')
+    local roles=('Reader' 'Storage Blob Data Owner')
+    for ((i=0; i < ${#roles[@]}; i++)); do
+        testAzureSecret "${roles[$i]}" ${subscription_id} ${resource_group_name} "role-${i}" ${CONFIG_DIR} ${ENGINE_NAME}
     done
-
 } >> $TESTS_OUT_FILE
 
 @test "Azure Secrets Engine - MS Graph" {
-    pushd ${CONFIG_DIR}/terraform
-    terraform init && terraform apply -input=false -auto-approve -var legacy_aad_resource_access=false
-    local tf_output=$(terraform output -json | tee ${CONFIG_DIR}/tf-output.json)
-    popd
+    local tf_output_file=${CONFIG_DIR}/tf-output.json
+    terraformInitApply ${CONFIG_DIR}
+    terraformOutput ${CONFIG_DIR} > ${tf_output_file}
 
-    # TODO: remove this sleep, tests periodically fail if the credentials created during infrastructure
-    # provisioning are not considered valid by Azure. Need to find a way to poll for the creds status.
-    sleep 10
+    tfOutputLocalEnv ${tf_output_file} > ${CONFIG_DIR}/local.env
+    . ${CONFIG_DIR}/local.env
+    local >&2
 
-    local client_id="$(echo ${tf_output} | jq -er .application_id.value)"
-    local client_secret="$(echo ${tf_output} | jq -er .application_password_value.value)"
-    local subscription_id="$(echo ${tf_output} | jq -er .subscription_id.value)"
-    local resource_group_name="$(echo ${tf_output} | jq -er .resource_group_name.value)"
-    local tenant_id="$(echo ${tf_output} | jq -er .tenant_id.value)"
-
-    vault secrets enable azure
-
-    vault write azure/config \
+    vault secrets enable ${ENGINE_NAME}
+    vault write "${ENGINE_NAME}/config" \
         use_microsoft_graph_api=true \
         subscription_id="${subscription_id}" \
         tenant_id="${tenant_id}" \
         client_id="${client_id}" \
         client_secret="${client_secret}"
 
-    local ttl=10
-    vault write azure/roles/my-role ttl="${ttl}" azure_roles=-<<EOF
-[
-    {
-        "role_name": "Reader",
-        "scope":  "/subscriptions/${subscription_id}/resourceGroups/${resource_group_name}"
-    }
-]
-EOF
-    local secret="$(vault read azure/creds/my-role -format=json)"
-    local sp_id="$(echo ${secret} | jq -er .data.client_id)"
-    local sp="$(az ad sp show --id "${sp_id}")"
-    echo ${secret} | jq
-    echo ${sp} | jq
+    # Azure API access provisioning seems to be delayed for whatever reason, so sleep a bit.
+    sleep 30
 
-    sleep ${ttl}
-    local tries=0
-    # wait for the service principal to expire and be removed by Vault - adds a 5 second buffer.
-    until ! az ad sp show --id "${sp_id}" > /dev/null
-    do
-        if [[ "${tries}" -ge 10 ]]; then
-            echo "vault failed to remove service principal ${sp_id}, ttl=${ttl}" >&2
-            exit 1
-        fi
-        ((++tries))
-        sleep .5
+    local roles=('Reader' 'Storage Blob Data Owner')
+    for ((i=0; i < ${#roles[@]}; i++)); do
+        testAzureSecret "${roles[$i]}" ${subscription_id} ${resource_group_name} "role-${i}" ${CONFIG_DIR} ${ENGINE_NAME}
     done
-
 } >> $TESTS_OUT_FILE

--- a/tests/acceptance/common.sh
+++ b/tests/acceptance/common.sh
@@ -37,11 +37,11 @@ EOF
     log "Secret created successfully, azure_role='${role_name}', vault_role='${vault_role_name}', file=${secret_file}"
 
     if !assertSPExistence ; then
-        exit 1
+        return 1
     fi
 
     if !waitLeaseExpiration ${role_name} ${vault_role_name} ${sp_id} ${ttl}; then
-        exit 1
+        return 1
     fi
 
     log "Test completed successfully, azure_role='${role_name}', vault_role='${vault_role_name}'"
@@ -72,7 +72,7 @@ function assertSPExistence() {
     local found=''
     for n in {0..30}
     do
-         if ! az ad sp show --id "${sp_id}" >&1 /dev/null ; then
+         if ! az ad sp show --id "${sp_id}" 1> /dev/null ; then
             logWarn "Failed to check service principal exists for ID ${sp_id}"
             sleep 1
             continue

--- a/tests/acceptance/common.sh
+++ b/tests/acceptance/common.sh
@@ -1,0 +1,120 @@
+function log() {
+    local level="${2:-INFO}"
+    echo "[$(TZ=UTC date --rfc-3339=ns) ${level} ${BATS_TEST_NAME}] $1"
+}
+
+function logError() {
+    log $1 'ERROR'
+}
+
+function logWarn() {
+    log $1 'WARN'
+}
+
+function testAzureSecret() {
+    local role_name="$1"
+    local subscription_id="$2"
+    local resource_group_name="$3"
+    local vault_role_name="$4"
+    local config_dir="$5"
+    local engine_name="$6"
+    local ttl=5
+
+    log "Creating Azure secret, azure_role='${role_name}', vault_role='${vault_role_name}'"
+    vault write "${engine_name}/roles/${vault_role_name}" ttl="${ttl}" azure_roles=-<<EOF
+[
+    {
+        "role_name": "${role_name}",
+        "scope":  "/subscriptions/${subscription_id}/resourceGroups/${resource_group_name}"
+    }
+]
+EOF
+
+    local secret_file="${config_dir}/secret-${vault_role_name}.json"
+    vault read "${engine_name}/creds/${vault_role_name}" -format=json > ${secret_file}
+
+    sp_id=$(cat "${secret_file}" | jq -er .data.client_id)
+    log "Secret created successfully, azure_role='${role_name}', vault_role='${vault_role_name}', file=${secret_file}"
+
+    local found=''
+    for n in {0..30}
+    do
+         if ! az ad sp show --id "${sp_id}" > /dev/null ; then
+            logWarn "Failed to check service principal exists for ID ${sp_id}"
+            sleep 1
+            continue
+         fi
+         found=1
+         break
+    done
+
+    if [ -z "${found}" ]; then
+        logError "Expected SP ID '${sp_id}' not found in Azure"
+        exit 1
+    fi
+
+    log "Waiting for lease expiration, azure_role='${role_name}', vault_role='${vault_role_name}'"
+    sleep ${ttl}
+    local tries=0
+    # wait for the service principal to expire and be removed by Vault - adds a 60 second buffer to the ttl.
+    until ! az ad sp show --id "${sp_id}" &> /dev/null
+    do
+        if [[ "${tries}" -ge 60 ]]; then
+            logError "Vault failed to remove service principal ${sp_id}, ttl=${ttl}"
+            exit 1
+        fi
+        ((++tries))
+        sleep 1
+    done
+    log "Test completed successfully, azure_role='${role_name}', vault_role='${vault_role_name}'"
+}
+
+function execTerraform() {
+    local config_dir="$1"
+    pushd ${config_dir}/terraform >&2
+    echo terraform ${@:2} >&2
+    terraform ${@:2}
+    popd >&2
+}
+
+function terraformInit() {
+    local config_dir="$1"
+    execTerraform ${config_dir} init
+}
+
+function terraformApply() {
+    local config_dir="$1"
+    execTerraform ${config_dir} apply -input=false -auto-approve ${@:2}
+}
+
+function terraformInitApply() {
+    terraformInit $@
+    terraformApply $@
+}
+
+function terraformOutput() {
+    local config_dir="$1"
+    execTerraform ${config_dir} output -json
+}
+
+function terraformDestroy() {
+    local config_dir="$1"
+    execTerraform ${config_dir} apply -input=false -auto-approve -destroy ${@:2}
+}
+
+function tfOutputLocalEnv() {
+    local output_file="$1"
+    tf_output=$(cat ${output_file}) || return $?
+    client_id="$(echo ${tf_output} | jq -er .application_id.value)" || return $?
+    client_secret="$(echo ${tf_output} | jq -er .application_password_value.value)" || return $?
+    subscription_id="$(echo ${tf_output} | jq -er .subscription_id.value)" || return $?
+    resource_group_name="$(echo ${tf_output} | jq -er .resource_group_name.value)" || return $?
+    tenant_id="$(echo ${tf_output} | jq -er .tenant_id.value)" || return $?
+    cat <<HERE
+local client_id="${client_id}"
+local client_secret="${client_secret}"
+local subscription_id="${subscription_id}"
+local resource_group_name="${resource_group_name}"
+local tenant_id="${tenant_id}"
+HERE
+}


### PR DESCRIPTION
The permissions for the MS Graph tests were incomplete, unfortunately
the issue was not caught by the bats test. Essentially doing a local
variable assignment from a sub-shell's stdout does not result in the
test failing when the sub-shell exits with a non-zero status

Summary of fixes:
- bats: add support testing Azure data plane roles
- terraform: ensure that 'MS Graph' test has all required permissions for
  the plugin to generate secrets
- terraform: wait for grant assignment after `admin-consent`
- bats: factor out common code to `common.sh`
- bats: ensure that all variable assignment from sub-shell values fail the
  test in the case that the sub-shell process exits with a non-zero
  status
- bats: add better test logging
- bats: add support for specifying a custom log file
- build: optionally build the plugin for the target vault docker image
  os/arch
- build: extend to better support bats acceptance test from make

