### PR TITLE
Fix bug where graph API didn't change when environment is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Next
+
+* Fixes environment not being used when using MS Graph [[GH-87](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/87)]

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -15,21 +15,33 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const (
-	// DefaultGraphMicrosoftComURI is the default URI used for the service MS Graph API
-	DefaultGraphMicrosoftComURI = "https://graph.microsoft.com"
-)
-
 var _ ApplicationsClient = (*AppClient)(nil)
 var _ GroupsClient = (*AppClient)(nil)
 var _ ServicePrincipalClient = (*AppClient)(nil)
 
 type AppClient struct {
-	client authorization.BaseClient
+	client   authorization.BaseClient
+	graphURI string
 }
 
-func NewMSGraphApplicationClient(subscriptionId string, userAgentExtension string, auth autorest.Authorizer) (*AppClient, error) {
-	client := authorization.NewWithBaseURI(DefaultGraphMicrosoftComURI, subscriptionId)
+// Reference: https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
+func GetGraphURI(env string) (string, error) {
+	switch env {
+	case "AzurePublicCloud":
+		return "https://graph.microsoft.com/", nil
+	case "AzureUSGovernmentCloud":
+		return "https://graph.microsoft.us/", nil
+	case "AzureGermanCloud":
+		return "https://graph.microsoft.de", nil
+	case "AzureChinaCloud":
+		return "https://microsoftgraph.chinacloudapi.cn", nil
+	default:
+		return "", fmt.Errorf("environment '%s' unknown", env)
+	}
+}
+
+func NewMSGraphApplicationClient(subscriptionId string, userAgentExtension string, graphURI string, auth autorest.Authorizer) (*AppClient, error) {
+	client := authorization.NewWithBaseURI(graphURI, subscriptionId)
 	client.Authorizer = auth
 
 	if userAgentExtension != "" {
@@ -40,7 +52,8 @@ func NewMSGraphApplicationClient(subscriptionId string, userAgentExtension strin
 	}
 
 	ac := &AppClient{
-		client: client,
+		client:   client,
+		graphURI: graphURI,
 	}
 	return ac, nil
 }
@@ -358,7 +371,7 @@ func (c AppClient) AddGroupMember(ctx context.Context, groupObjectID string, mem
 		"groupObjectID": groupObjectID,
 	}
 	body := map[string]interface{}{
-		"@odata.id": fmt.Sprintf("%s/v1.0/directoryObjects/%s", DefaultGraphMicrosoftComURI, memberObjectID),
+		"@odata.id": fmt.Sprintf("%s/v1.0/directoryObjects/%s", c.graphURI, memberObjectID),
 	}
 	preparer := c.GetPreparer(
 		autorest.AsPost(),

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -27,7 +27,7 @@ type AppClient struct {
 // Reference: https://docs.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
 func GetGraphURI(env string) (string, error) {
 	switch env {
-	case "AzurePublicCloud":
+	case "AzurePublicCloud", "":
 		return "https://graph.microsoft.com/", nil
 	case "AzureUSGovernmentCloud":
 		return "https://graph.microsoft.us/", nil

--- a/provider.go
+++ b/provider.go
@@ -38,12 +38,17 @@ func newAzureProvider(settings *clientSettings, useMsGraphApi bool, passwords ap
 	var groupsClient api.GroupsClient
 	var spClient api.ServicePrincipalClient
 	if useMsGraphApi {
-		graphApiAuthorizer, err := getAuthorizer(settings, api.DefaultGraphMicrosoftComURI)
+		graphURI, err := api.GetGraphURI(settings.Environment.Name)
 		if err != nil {
 			return nil, err
 		}
 
-		msGraphAppClient, err := api.NewMSGraphApplicationClient(settings.SubscriptionID, userAgent, graphApiAuthorizer)
+		graphApiAuthorizer, err := getAuthorizer(settings, graphURI)
+		if err != nil {
+			return nil, err
+		}
+
+		msGraphAppClient, err := api.NewMSGraphApplicationClient(settings.SubscriptionID, userAgent, graphURI, graphApiAuthorizer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The graph URL was hardcoded to `https://graph.microsoft.com` in the new Graph API, but the URL changes depending on the type of Azure cloud being used (set by `environment` in the config). This adds a new helper function to switch based on which cloud the user has configured.