### PR TITLE
Remove trailing slashes from graph URLs

### DIFF
--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -28,9 +28,9 @@ type AppClient struct {
 func GetGraphURI(env string) (string, error) {
 	switch env {
 	case "AzurePublicCloud", "":
-		return "https://graph.microsoft.com/", nil
+		return "https://graph.microsoft.com", nil
 	case "AzureUSGovernmentCloud":
-		return "https://graph.microsoft.us/", nil
+		return "https://graph.microsoft.us", nil
 	case "AzureGermanCloud":
 		return "https://graph.microsoft.de", nil
 	case "AzureChinaCloud":

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -59,8 +59,8 @@ func TestConfigEnvironmentClouds(t *testing.T) {
 		expError bool
 	}{
 		{"AZURECHINACLOUD", "https://microsoftgraph.chinacloudapi.cn", false},
-		{"AZUREPUBLICCLOUD", "https://graph.microsoft.com/", false},
-		{"AZUREUSGOVERNMENTCLOUD", "https://graph.microsoft.us/", false},
+		{"AZUREPUBLICCLOUD", "https://graph.microsoft.com", false},
+		{"AZUREUSGOVERNMENTCLOUD", "https://graph.microsoft.us", false},
 		{"AZUREGERMANCLOUD", "https://graph.microsoft.de", false},
 		{"invalidEnv", "", true},
 	}


### PR DESCRIPTION
Two URLs had trailing slashes. These did not effect functionality but cleaning this up for consistency. 