### PR TITLE
Backport 1.9.x: Fix bug where graph API didn't change when environment is set (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Next
+
+* Fixes environment not being used when using MS Graph [[GH-87](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/87)]

--- a/api/application_msgraph.go
+++ b/api/application_msgraph.go
@@ -28,9 +28,9 @@ type AppClient struct {
 func GetGraphURI(env string) (string, error) {
 	switch env {
 	case "AzurePublicCloud", "":
-		return "https://graph.microsoft.com/", nil
+		return "https://graph.microsoft.com", nil
 	case "AzureUSGovernmentCloud":
-		return "https://graph.microsoft.us/", nil
+		return "https://graph.microsoft.us", nil
 	case "AzureGermanCloud":
 		return "https://graph.microsoft.de", nil
 	case "AzureChinaCloud":

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -59,8 +59,8 @@ func TestConfigEnvironmentClouds(t *testing.T) {
 		expError bool
 	}{
 		{"AZURECHINACLOUD", "https://microsoftgraph.chinacloudapi.cn", false},
-		{"AZUREPUBLICCLOUD", "https://graph.microsoft.com/", false},
-		{"AZUREUSGOVERNMENTCLOUD", "https://graph.microsoft.us/", false},
+		{"AZUREPUBLICCLOUD", "https://graph.microsoft.com", false},
+		{"AZUREUSGOVERNMENTCLOUD", "https://graph.microsoft.us", false},
 		{"AZUREGERMANCLOUD", "https://graph.microsoft.de", false},
 		{"invalidEnv", "", true},
 	}

--- a/provider.go
+++ b/provider.go
@@ -38,12 +38,17 @@ func newAzureProvider(settings *clientSettings, useMsGraphApi bool, passwords ap
 	var groupsClient api.GroupsClient
 	var spClient api.ServicePrincipalClient
 	if useMsGraphApi {
-		graphApiAuthorizer, err := getAuthorizer(settings, api.DefaultGraphMicrosoftComURI)
+		graphURI, err := api.GetGraphURI(settings.Environment.Name)
 		if err != nil {
 			return nil, err
 		}
 
-		msGraphAppClient, err := api.NewMSGraphApplicationClient(settings.SubscriptionID, userAgent, graphApiAuthorizer)
+		graphApiAuthorizer, err := getAuthorizer(settings, graphURI)
+		if err != nil {
+			return nil, err
+		}
+
+		msGraphAppClient, err := api.NewMSGraphApplicationClient(settings.SubscriptionID, userAgent, graphURI, graphApiAuthorizer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport of #87 and #88.