### PR TITLE
Allows for persisting an app for the lifetime of the role

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
@@ -181,10 +182,13 @@ func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRol
 // attempt is made to remove all assignments, and not return immediately if there
 // is an error.
 func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
+	logger := hclog.New(&hclog.LoggerOptions{})
+
 	var merr *multierror.Error
 
 	for _, id := range roleIDs {
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctx, id); err != nil {
+			logger.Info("error: %s", err)
 			merr = multierror.Append(merr, fmt.Errorf("error unassigning role: %w", err))
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -56,6 +56,15 @@ func (c *client) createApp(ctx context.Context) (app *api.ApplicationResult, err
 	return &result, err
 }
 
+func (c *client) createAppWithName(ctx context.Context, rolename string) (app *api.ApplicationResult, err error) {
+	intSuffix := fmt.Sprintf("%d", time.Now().Unix())
+	name := fmt.Sprintf("%s%s-%s", appNamePrefix, rolename, intSuffix)
+
+	result, err := c.provider.CreateApplication(ctx, name)
+
+	return &result, err
+}
+
 // createSP creates a new service principal.
 func (c *client) createSP(
 	ctx context.Context,
@@ -299,9 +308,9 @@ func (b *azureSecretBackend) getClientSettings(ctx context.Context, config *azur
 
 // retry will repeatedly call f until one of:
 //
-//   * f returns true
-//   * the context is cancelled
-//   * 80 seconds elapses. Vault's default request timeout is 90s; we want to expire before then.
+//   - f returns true
+//   - the context is cancelled
+//   - 80 seconds elapses. Vault's default request timeout is 90s; we want to expire before then.
 //
 // Delays are random but will average 5 seconds.
 func retry(ctx context.Context, f func() (interface{}, bool, error)) (interface{}, error) {

--- a/path_roles.go
+++ b/path_roles.go
@@ -219,7 +219,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 	if persistApp, ok := d.GetOk("persist_app"); ok {
 		role.PersistApp = persistApp.(bool)
 		// set the applicationObjectID to the managedApplicationObjectID so that we can use the same SP logic as static.
-		if role.ManagedApplicationObjectID != "" {
+		if role.PersistApp {
 			role.ApplicationObjectID = role.ManagedApplicationObjectID
 		}
 	}

--- a/path_roles.go
+++ b/path_roles.go
@@ -486,7 +486,7 @@ func (b *azureSecretBackend) pathRoleDelete(ctx context.Context, req *logical.Re
 		// removing group membership is effectively a garbage collection operation.
 		c.removeGroupMemberships(ctx, role.SpObjID, role.GmIDs)
 
-		if err = c.deleteApp(ctx, role.ApplicationObjectID); err != nil {
+		if err = c.deleteApp(ctx, role.ApplicationObjectID, role.PermanentlyDelete); err != nil {
 			return nil, fmt.Errorf("error deleting persisted app: %w", err)
 		}
 	}

--- a/path_roles.go
+++ b/path_roles.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
@@ -340,24 +339,17 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 }
 
 func (b *azureSecretBackend) createPersistedApp(ctx context.Context, req *logical.Request, role *roleEntry, name string) error {
-
-	logger := hclog.New(&hclog.LoggerOptions{})
-
 	c, err := b.getClient(ctx, req.Storage)
 	if err != nil {
 		return err
 	}
 
 	if role.ManagedApplicationObjectID != "" {
-		logger.Info("updating existing app")
-
-		// unassigning roles
-		// TODO: this is super fragile. . . if someone deletes an assignment manually this could break.
+		// Unassign roles
 		if err := c.unassignRoles(ctx, role.RaIDs); err != nil {
 			return err
 		}
-		// removing group membership
-		// TODO: this is super fragile. . . if someone deletes an assignment manually this could break.
+		// Removing group membership
 		if err := c.removeGroupMemberships(ctx, role.SpObjID, role.GmIDs); err != nil {
 			return err
 		}
@@ -380,7 +372,6 @@ func (b *azureSecretBackend) createPersistedApp(ctx context.Context, req *logica
 		return nil
 	}
 
-	logger.Info("creating new app")
 	app, err := c.createAppWithName(ctx, name)
 	if err != nil {
 		return err

--- a/path_roles.go
+++ b/path_roles.go
@@ -459,7 +459,7 @@ func (b *azureSecretBackend) pathRoleList(ctx context.Context, req *logical.Requ
 }
 
 func (b *azureSecretBackend) pathRoleDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	resp := new(logical.Response)
+	var resp *logical.Response
 
 	name := d.Get("name").(string)
 	role, err := getRole(ctx, name, req.Storage)
@@ -474,9 +474,10 @@ func (b *azureSecretBackend) pathRoleDelete(ctx context.Context, req *logical.Re
 		}
 
 		// unassigning roles and removing group membership is effectively a garbage collection operation.
-		// Errors will be noted but won't fail the revocation process. 
+		// Errors will be noted but won't fail the revocation process.
 		// Deleting the app, however, *is* required to consider the secret revoked.
 		if err := removeRolesAndGroupMembership(ctx, c, role); err != nil {
+			resp = new(logical.Response)
 			resp.AddWarning(err.Error())
 		}
 

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -40,6 +40,7 @@ func TestRoleCreate(t *testing.T) {
 			"max_ttl":               int64(0),
 			"application_object_id": "",
 			"permanently_delete":    true,
+			"persist_app":           false,
 		}
 
 		spRole2 := map[string]interface{}{
@@ -67,6 +68,7 @@ func TestRoleCreate(t *testing.T) {
 			"max_ttl":               int64(3000),
 			"application_object_id": "",
 			"permanently_delete":    true,
+			"persist_app":           false,
 		}
 
 		// Verify basic updates of the name role
@@ -96,6 +98,7 @@ func TestRoleCreate(t *testing.T) {
 			"azure_roles":           "[]",
 			"azure_groups":          "[]",
 			"permanently_delete":    false,
+			"persist_app":           false,
 		}
 
 		name := generateUUID()
@@ -119,6 +122,7 @@ func TestRoleCreate(t *testing.T) {
 			),
 			"application_object_id": "",
 			"azure_groups":          "[]",
+			"persist_app":           false,
 		}
 
 		// Verify that ttl and max_ttl are 0 if not provided

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -175,13 +175,12 @@ func TestRoleCreate(t *testing.T) {
 		convertRespTypes(resp.Data)
 		assertNotEmptyString(t, resp.Data["application_object_id"].(string))
 
-
 		fullRole, err = getRole(context.Background(), name, s)
 		assertErrorIsNil(t, err)
 
 		equal(t, fullRole.ApplicationID, originalAppID)
 		equal(t, fullRole.ApplicationObjectID, originalAppObjID)
-		
+
 	})
 
 	t.Run("Static SP role", func(t *testing.T) {

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -161,9 +161,9 @@ func TestRoleCreate(t *testing.T) {
 
 		assertNotNil(t, fullRole.ApplicationID)
 		assertNotNil(t, fullRole.ApplicationObjectID)
-		assertStrSliceIsNotEmpty(t, fullRole.GmIDs)
-		assertStrSliceIsNotEmpty(t, fullRole.RaIDs)
-		assertNotNil(t, fullRole.SpObjID)
+		assertStrSliceIsNotEmpty(t, fullRole.GroupMembershipIDs)
+		assertStrSliceIsNotEmpty(t, fullRole.RoleAssignmentIDs)
+		assertNotNil(t, fullRole.ServicePrincipalObjectID)
 
 		originalAppID := fullRole.ApplicationID
 		originalAppObjID := fullRole.ApplicationObjectID

--- a/path_rotate_root_test.go
+++ b/path_rotate_root_test.go
@@ -241,6 +241,20 @@ func assertNotNil(t *testing.T, val interface{}) {
 	}
 }
 
+func assertNotEmptyString(t *testing.T, str string) {
+	t.Helper()
+	if str == "" {
+		t.Fatalf("string is empty")
+	}
+}
+
+func assertStrSliceIsNotEmpty(t *testing.T, strs []string) {
+	t.Helper()
+	if strs == nil || len(strs) == 0 {
+		t.Fatalf("string slice is empty")
+	}
+}
+
 func assertStrSliceIsEmpty(t *testing.T, strs []string) {
 	t.Helper()
 	if strs != nil && len(strs) > 0 {

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -90,7 +90,6 @@ func (b *azureSecretBackend) pathSPRead(ctx context.Context, req *logical.Reques
 
 	resp.Secret.TTL = role.TTL
 	resp.Secret.MaxTTL = role.MaxTTL
-
 	return resp, nil
 }
 

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -84,7 +84,6 @@ var (
 		}),
 		"persist_app": true,
 	}
-
 )
 
 // TestSP_WAL_Cleanup tests that any Service Principal that gets created, but

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -68,6 +68,23 @@ var (
 	testStaticSPRole = map[string]interface{}{
 		"application_object_id": "00000000-0000-0000-0000-000000000000",
 	}
+
+	testPersistentRole = map[string]interface{}{
+		"azure_roles": encodeJSON([]AzureRole{
+			{
+				RoleName: "Owner",
+				RoleID:   "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Owner",
+				Scope:    "/subscriptions/ce7d1612-67c1-4dc6-8d81-4e0a432e696b",
+			},
+			{
+				RoleName: "Contributor",
+				RoleID:   "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
+				Scope:    "/subscriptions/ce7d1612-67c1-4dc6-8d81-4e0a432e696b",
+			},
+		}),
+		"persist_app": true,
+	}
+
 )
 
 // TestSP_WAL_Cleanup tests that any Service Principal that gets created, but
@@ -308,6 +325,80 @@ func TestStaticSPRead(t *testing.T) {
 	t.Run("TTLs", func(t *testing.T) {
 		name := generateUUID()
 		testRoleCreate(t, b, s, name, testStaticSPRole)
+
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		equal(t, 0*time.Second, resp.Secret.TTL)
+		equal(t, 0*time.Second, resp.Secret.MaxTTL)
+
+		roleUpdate := map[string]interface{}{
+			"ttl":     20,
+			"max_ttl": 30,
+		}
+		testRoleCreate(t, b, s, name, roleUpdate)
+
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		equal(t, 20*time.Second, resp.Secret.TTL)
+		equal(t, 30*time.Second, resp.Secret.MaxTTL)
+	})
+}
+
+func TestPersistentAppSPRead(t *testing.T) {
+	b, s := getTestBackend(t, true)
+
+	// verify basic cred issuance
+	t.Run("Basic", func(t *testing.T) {
+		name := generateUUID()
+		testRoleCreate(t, b, s, name, testPersistentRole)
+
+		resp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		if resp.IsError() {
+			t.Fatalf("expected no response error, actual:%#v", resp.Error())
+		}
+
+		// verify client_id format, and that the corresponding app actually exists
+		_, err = uuid.ParseUUID(resp.Data["client_id"].(string))
+		assertErrorIsNil(t, err)
+
+		keyID := resp.Secret.InternalData["key_id"].(string)
+		if len(keyID) == 0 {
+			t.Fatalf("expected keyId to not be empty")
+		}
+
+		client, err := b.getClient(context.Background(), s)
+		assertErrorIsNil(t, err)
+
+		if !client.provider.(*mockProvider).passwordExists(keyID) {
+			t.Fatalf("password was not created")
+		}
+
+		assertClientSecret(t, resp.Data)
+	})
+
+	// verify role TTLs are reflected in secret
+	t.Run("TTLs", func(t *testing.T) {
+		name := generateUUID()
+		testRoleCreate(t, b, s, name, testPersistentRole)
 
 		resp, err := b.HandleRequest(context.Background(), &logical.Request{
 			Operation: logical.ReadOperation,


### PR DESCRIPTION
# Overview
_A high level description of the contribution, including:_
Adds the ability to persist the created application between getting credentials.

_Who the change affects or is for (stakeholders)?_

Consumers of role definitions who may need to persist Service Principal application objects.

_What is the change?_ 

Adds a new field to the role schema that allows the application to persist for the lifetime of the role.

_Why is the change needed?_
 
Allows for the SPN to maintain ownership of resources created by it between runs.  This will be useful for another change we would like to make to allow SPNs to be assigned graphAPI permissions. Many of those permissions have something similar to the `Application.ReadWrite.OwnerBy` For this permission to work correctly we need to persist the app so that it still owns the resource. 
 
_How does this change affect the user experience (if at all)?_

No affect for existing roles, or roles that don’t use the new field.

# Design of Change
_How was this change implemented?_

On role creation, if `persist_app` is set to true, we then create a new app and bind it to the Azure roles and groups listed in the role.  We then set the `application_object_id` on the role so that we are able to reuse the `createStaticSPSecret` as the lifecycle of the credentials is the same as a static app.  

On role update we remove all Azure roles and group bindings, then create the new Azure role and group bindings. 

On role delete we delete all Azure role bindings and group membership (best effort) then the application. 


# Related Issues/Pull Requests


# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](https://github.com/hashicorp/vault/pull/16537)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
