### PR TITLE
Add option to permanently delete AzureAD objects

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,7 +31,7 @@ type AzureProvider interface {
 type ApplicationsClient interface {
 	GetApplication(ctx context.Context, applicationObjectID string) (ApplicationResult, error)
 	CreateApplication(ctx context.Context, displayName string) (ApplicationResult, error)
-	DeleteApplication(ctx context.Context, applicationObjectID string) error
+	DeleteApplication(ctx context.Context, applicationObjectID string, permanentlyDelete bool) error
 	ListApplications(ctx context.Context, filter string) ([]ApplicationResult, error)
 	AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime time.Time) (PasswordCredentialResult, error)
 	RemoveApplicationPassword(ctx context.Context, applicationObjectID string, keyID string) error

--- a/api/service_principals.go
+++ b/api/service_principals.go
@@ -8,6 +8,7 @@ import (
 type ServicePrincipalClient interface {
 	// CreateServicePrincipal in Azure. The password returned is the actual password that the appID was created with
 	CreateServicePrincipal(ctx context.Context, appID string, startDate time.Time, endDate time.Time) (id string, password string, err error)
+	DeleteServicePrincipal(ctx context.Context, spObjectID string, permanentlyDelete bool) error
 }
 
 type ServicePrincipal struct {

--- a/client.go
+++ b/client.go
@@ -121,8 +121,13 @@ func (c *client) deleteAppPassword(ctx context.Context, appObjID, keyID string) 
 }
 
 // deleteApp deletes an Azure application.
-func (c *client) deleteApp(ctx context.Context, appObjectID string) error {
-	return c.provider.DeleteApplication(ctx, appObjectID)
+func (c *client) deleteApp(ctx context.Context, appObjectID string, permanentlyDelete bool) error {
+	return c.provider.DeleteApplication(ctx, appObjectID, permanentlyDelete)
+}
+
+// deleteServicePrincipal deletes an Azure service principal.
+func (c *client) deleteServicePrincipal(ctx context.Context, spObjectID string, permanentlyDelete bool) error {
+	return c.provider.DeleteServicePrincipal(ctx, spObjectID, permanentlyDelete)
 }
 
 // assignRoles assigns Azure roles to a service principal.

--- a/path_config.go
+++ b/path_config.go
@@ -42,36 +42,36 @@ func pathConfig(b *azureSecretBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: "config",
 		Fields: map[string]*framework.FieldSchema{
-			"subscription_id": &framework.FieldSchema{
+			"subscription_id": {
 				Type: framework.TypeString,
 				Description: `The subscription id for the Azure Active Directory.
 				This value can also be provided with the AZURE_SUBSCRIPTION_ID environment variable.`,
 			},
-			"tenant_id": &framework.FieldSchema{
+			"tenant_id": {
 				Type: framework.TypeString,
 				Description: `The tenant id for the Azure Active Directory. This value can also
 				be provided with the AZURE_TENANT_ID environment variable.`,
 			},
-			"environment": &framework.FieldSchema{
+			"environment": {
 				Type: framework.TypeString,
 				Description: `The Azure environment name. If not provided, AzurePublicCloud is used.
 				This value can also be provided with the AZURE_ENVIRONMENT environment variable.`,
 			},
-			"client_id": &framework.FieldSchema{
+			"client_id": {
 				Type: framework.TypeString,
 				Description: `The OAuth2 client id to connect to Azure.
 				This value can also be provided with the AZURE_CLIENT_ID environment variable.`,
 			},
-			"client_secret": &framework.FieldSchema{
+			"client_secret": {
 				Type: framework.TypeString,
 				Description: `The OAuth2 client secret to connect to Azure.
 				This value can also be provided with the AZURE_CLIENT_SECRET environment variable.`,
 			},
-			"password_policy": &framework.FieldSchema{
+			"password_policy": {
 				Type:        framework.TypeString,
 				Description: "Name of the password policy to use to generate passwords for dynamic credentials.",
 			},
-			"root_password_ttl": &framework.FieldSchema{
+			"root_password_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Default:     defaultRootPasswordTTL,
 				Description: "The TTL of the root password in Azure. This can be either a number of seconds or a time formatted duration (ex: 24h, 48ds)",

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -39,6 +39,7 @@ func TestRoleCreate(t *testing.T) {
 			"ttl":                   int64(0),
 			"max_ttl":               int64(0),
 			"application_object_id": "",
+			"permanently_delete":    true,
 		}
 
 		spRole2 := map[string]interface{}{
@@ -65,6 +66,7 @@ func TestRoleCreate(t *testing.T) {
 			"ttl":                   int64(300),
 			"max_ttl":               int64(3000),
 			"application_object_id": "",
+			"permanently_delete":    true,
 		}
 
 		// Verify basic updates of the name role
@@ -93,6 +95,7 @@ func TestRoleCreate(t *testing.T) {
 			"max_ttl":               int64(3000),
 			"azure_roles":           "[]",
 			"azure_groups":          "[]",
+			"permanently_delete":    false,
 		}
 
 		name := generateUUID()
@@ -119,11 +122,13 @@ func TestRoleCreate(t *testing.T) {
 		}
 
 		// Verify that ttl and max_ttl are 0 if not provided
+		// and that permanently_delete is false if not provided
 		name := generateUUID()
 		testRoleCreate(t, b, s, name, testRole)
 
 		testRole["ttl"] = int64(0)
 		testRole["max_ttl"] = int64(0)
+		testRole["permanently_delete"] = false
 
 		resp, err := testRoleRead(t, b, s, name)
 		assertErrorIsNil(t, err)

--- a/provider.go
+++ b/provider.go
@@ -121,8 +121,8 @@ func (p *provider) ListApplications(ctx context.Context, filter string) ([]api.A
 
 // DeleteApplication deletes an Azure application object.
 // This will in turn remove the service principal (but not the role assignments).
-func (p *provider) DeleteApplication(ctx context.Context, applicationObjectID string) error {
-	return p.appClient.DeleteApplication(ctx, applicationObjectID)
+func (p *provider) DeleteApplication(ctx context.Context, applicationObjectID string, permanentlyDelete bool) error {
+	return p.appClient.DeleteApplication(ctx, applicationObjectID, permanentlyDelete)
 }
 
 func (p *provider) AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime time.Time) (result api.PasswordCredentialResult, err error) {
@@ -137,6 +137,10 @@ func (p *provider) RemoveApplicationPassword(ctx context.Context, applicationObj
 // An Application must be created prior to calling this and pass in parameters.
 func (p *provider) CreateServicePrincipal(ctx context.Context, appID string, startDate time.Time, endDate time.Time) (id string, password string, err error) {
 	return p.spClient.CreateServicePrincipal(ctx, appID, startDate, endDate)
+}
+
+func (p *provider) DeleteServicePrincipal(ctx context.Context, spObjectID string, permanentlyDelete bool) error {
+	return p.spClient.DeleteServicePrincipal(ctx, spObjectID, permanentlyDelete)
 }
 
 // ListRoles like all Azure roles with a scope (often subscription).

--- a/wal.go
+++ b/wal.go
@@ -60,7 +60,7 @@ func (b *azureSecretBackend) rollbackAppWAL(ctx context.Context, req *logical.Re
 	// found, so no special handling is needed for that case. If we don't succeed within
 	// maxWALAge (e.g. client creds have changed and the delete will never succeed),
 	// unconditionally remove the WAL.
-	if err := client.deleteApp(ctx, entry.AppObjID); err != nil {
+	if err := client.deleteApp(ctx, entry.AppObjID, false); err != nil {
 		b.Logger().Warn("rollback error deleting App", "err", err)
 
 		if time.Now().After(entry.Expiration) {


### PR DESCRIPTION
# Overview
This PR allows for permanent deletion of AzureAD apps and service principals that are created by the secrets engine. Traditionally, the Vault secrets engine does not permanently delete the service principals/apps from AzureAD when leases expire. Instead, the objects are placed in a "recycle bin," and they count toward the [limit of AzureAD objects in a tenant](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#active-directory-limits) (that limit ranges from 50k to 500k objects). So after 50k-500k leases, Vault hits the limit of objects in an Azure AD and causes all create operations on the tenant to fail.

# Design of Change
How was this change implemented?
Added an optional field `permanently_delete` to the `role` path that defaults to `false` which invokes legacy behavior. If `permanently_delete` is set to `true`, the applications and service principals created by Vault will be permanently deleted when the corresponding leases expire.

# Related Issues/Pull Requests
[x] [Issue #103](https://github.com/hashicorp/vault-plugin-secrets-azure/issues/103)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x ] Backwards compatible
