### PR TITLE
Fix up acceptance tests to use the latest provider versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 # Acceptance test variables
-WITH_DEV_PLUGIN?=
+WITH_DEV_PLUGIN?=1
 AZURE_TENANT_ID?=
 SKIP_TEARDOWN?=
 TESTS_OUT_FILE?=

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: fmtcheck generate
 
 # test-acceptance runs all acceptance tests
 test-acceptance: $(if $(WITH_DEV_PLUGIN), dev-acceptance)
-	bats -f $(TESTS_FILTER) $(CURDIR)/tests/acceptance/basic.bats
+	 WITH_DEV_PLUGIN=$(WITH_DEV_PLUGIN) bats -f $(TESTS_FILTER) $(CURDIR)/tests/acceptance/basic.bats
 
 # generate runs `go generate` to build the dynamically generated
 # source files.

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ for more information.
 $ make test-acceptance AZURE_TENANT_ID=<your_tenant_id>
 ```
 
-Setting `WITH_DEV_PLUGIN=1` will first build the local plugin, and automatically register
-it with the test Vault instance.
+Setting `WITH_DEV_PLUGIN=` will use the provided builtin plugin. The default behavior is to build and register
+the plugin from the working directory.
 
 ```sh
-$ make test-acceptance AZURE_TENANT_ID=<your_tenant_id> WITH_DEV_PLUGIN=1
+$ make test-acceptance AZURE_TENANT_ID=<your_tenant_id>
 ```
 
 Running tests against Vault Enterprise requires a valid license, and specifying an enterprise docker image:

--- a/client.go
+++ b/client.go
@@ -299,9 +299,9 @@ func (b *azureSecretBackend) getClientSettings(ctx context.Context, config *azur
 
 // retry will repeatedly call f until one of:
 //
-//   * f returns true
-//   * the context is cancelled
-//   * 80 seconds elapses. Vault's default request timeout is 90s; we want to expire before then.
+//   - f returns true
+//   - the context is cancelled
+//   - 80 seconds elapses. Vault's default request timeout is 90s; we want to expire before then.
 //
 // Delays are random but will average 5 seconds.
 func retry(ctx context.Context, f func() (interface{}, bool, error)) (interface{}, error) {

--- a/path_roles.go
+++ b/path_roles.go
@@ -120,13 +120,14 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 //   Given just role name, a search will be performed and if exactly one match is found,
 //   that role will be used.
 
-//   Azure groups are checked for existence. The Azure groups lookup step will allow the
-//   operator to provide a groups name or ID. ID is unambigious and will be used if provided.
-//   Given just group name, a search will be performed and if exactly one match is found,
-//   that group will be used.
+//	Azure groups are checked for existence. The Azure groups lookup step will allow the
+//	operator to provide a groups name or ID. ID is unambigious and will be used if provided.
+//	Given just group name, a search will be performed and if exactly one match is found,
+//	that group will be used.
 //
 // Static Service Principal:
-//   The provided Application Object ID is checked for existence.
+//
+//	The provided Application Object ID is checked for existence.
 func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	var resp *logical.Response
 

--- a/tests/acceptance/basic.bats
+++ b/tests/acceptance/basic.bats
@@ -6,7 +6,7 @@ load common.sh
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PLUGIN_NAME="${REPO_ROOT##*/}"
-VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.9.3}"
+VAULT_IMAGE="${VAULT_IMAGE:-hashicorp/vault:1.12.1}"
 CONTAINER_NAME=''
 VAULT_TOKEN='root'
 
@@ -95,6 +95,7 @@ HERE
     vault audit enable file file_path=stdout
 
     if [[ -n "${WITH_DEV_PLUGIN}" ]]; then
+        log "Registering vault plugin"
         cp -a ${PLUGIN} ${CONFIG_DIR}/plugins/.
         # replace the builtin plugin with a local build
         vault plugin register -sha256="${PLUGIN_SHA256}" -command=${PLUGIN_NAME} ${PLUGIN_TYPE} ${ENGINE_NAME}

--- a/tests/acceptance/common.sh
+++ b/tests/acceptance/common.sh
@@ -1,6 +1,16 @@
+if which gdate &> /dev/null ; then
+  function __date_cmd() {
+    TZ=UTC gdate --rfc-3339=ns
+  }
+else
+  function __date_cmd() {
+    TZ=UTC date -Iseconds
+  }
+fi
+
 function log() {
     local level="${2:-INFO}"
-    echo "[$(TZ=UTC date --rfc-3339=ns) ${level} ${BATS_TEST_NAME}] $1"
+    echo "[$(__date_cmd) ${level} ${BATS_TEST_NAME:-unknown}] $1"
 }
 
 function logError() {

--- a/tests/acceptance/terraform/main.tf
+++ b/tests/acceptance/terraform/main.tf
@@ -11,11 +11,11 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.84.0"
+      version = "3.29.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.8.0"
+      version = "2.30.0"
     }
     time = {
       source  = "hashicorp/time"
@@ -41,11 +41,6 @@ variable "tenant_id" {
 variable "name_prefix" {
   description = "Prefix all resources with name."
 
-}
-variable "legacy_aad_resource_access" {
-  description = "Provision AD application with Azure Active Directory Graph API access"
-  type        = bool
-  default     = false
 }
 
 resource "random_id" "name" {
@@ -75,36 +70,33 @@ resource "azuread_application" "vault_azure_secrets" {
   }
 
 
-  dynamic "required_resource_access" {
-    for_each = var.legacy_aad_resource_access ? [] : [""]
+  required_resource_access {
     # Microsoft Graph
-    content {
-      resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
 
-      resource_access {
-        id   = "df021288-bdef-4463-88db-98f22de89214" # User.Read.All
-        type = "Role"
-      }
+    resource_access {
+      id   = "df021288-bdef-4463-88db-98f22de89214" # User.Read.All
+      type = "Role"
+    }
 
-      resource_access {
-        id   = "b4e74841-8e56-480b-be8b-910348b18b4c" # User.ReadWrite
-        type = "Scope"
-      }
+    resource_access {
+      id   = "b4e74841-8e56-480b-be8b-910348b18b4c" # User.ReadWrite
+      type = "Scope"
+    }
 
-      resource_access {
-        id   = "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9" # Application.ReadWrite.All
-        type = "Role"
-      }
+    resource_access {
+      id   = "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9" # Application.ReadWrite.All
+      type = "Role"
+    }
 
-      resource_access {
-        id   = "19dbc75e-c2e2-444c-a770-ec69d8559fc7" # Directory.ReadWrite.All
-        type = "Role"
-      }
+    resource_access {
+      id   = "19dbc75e-c2e2-444c-a770-ec69d8559fc7" # Directory.ReadWrite.All
+      type = "Role"
+    }
 
-      resource_access {
-        id   = "62a82d76-70ea-41e2-9197-370581804d09" # Group.ReadWrite.All
-        type = "Role"
-      }
+    resource_access {
+      id   = "62a82d76-70ea-41e2-9197-370581804d09" # Group.ReadWrite.All
+      type = "Role"
     }
   }
 }


### PR DESCRIPTION
- default WITH_DEV_PLUGIN to 1 so that we are always testing the local code.
- other misc. fixes

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
