### PR TITLE
Backport 1.10: Implement WAL rollback mechanism for Role Assignments (#110)

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,17 +126,19 @@ func (c *client) deleteApp(ctx context.Context, appObjectID string) error {
 }
 
 // assignRoles assigns Azure roles to a service principal.
-func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRole) ([]string, error) {
+func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRole, assignmentIDs []string) ([]string, error) {
 	var ids []string
 
-	for _, role := range roles {
-		assignmentID, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, err
-		}
+	if len(roles) != len(assignmentIDs) {
+		return nil, errors.New("number of Azure Roles and assignment IDs do not match")
+	}
 
+	for i, role := range roles {
 		resultRaw, err := retry(ctx, func() (interface{}, bool, error) {
-			ra, err := c.provider.CreateRoleAssignment(ctx, role.Scope, assignmentID,
+			if assignmentIDs[i] == "" {
+				return nil, true, fmt.Errorf("assignmentID at index %d was empty", i)
+			}
+			ra, err := c.provider.CreateRoleAssignment(ctx, role.Scope, assignmentIDs[i],
 				authorization.RoleAssignmentCreateParameters{
 					RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 						RoleDefinitionID: &role.RoleID,

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -113,37 +113,63 @@ func assertEmptyWAL(t *testing.T, b *azureSecretBackend, emp api.AzureProvider, 
 			t.Fatal(err)
 		}
 
-		// Decode the WAL data
-		var app walApp
-		d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-			DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
-			Result:     &app,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = d.Decode(entry.Data)
-		if err != nil {
-			t.Fatal(err)
+		switch entry.Kind {
+		case walAppKey:
+			// Decode the WAL data
+			var app walApp
+			d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+				Result:     &app,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = d.Decode(entry.Data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = emp.GetApplication(context.Background(), app.AppObjID)
+			if err != nil {
+				t.Fatalf("expected to find application (%s), but wasn't found", app.AppObjID)
+			}
+
+			err = b.walRollback(ctx, req, entry.Kind, entry.Data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := framework.DeleteWAL(ctx, s, v); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = emp.GetApplication(context.Background(), app.AppObjID)
+			if err == nil {
+				t.Fatalf("expected error getting application")
+			}
+		case walAppRoleAssignment:
+			// Decode the WAL data
+			d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+				Result:     &entry,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = d.Decode(entry.Data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = b.walRollback(ctx, req, entry.Kind, entry.Data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := framework.DeleteWAL(ctx, s, v); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		_, err = emp.GetApplication(context.Background(), app.AppObjID)
-		if err != nil {
-			t.Fatalf("expected to find application (%s), but wasn't found", app.AppObjID)
-		}
-
-		err = b.walRollback(ctx, req, entry.Kind, entry.Data)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := framework.DeleteWAL(ctx, s, v); err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = emp.GetApplication(context.Background(), app.AppObjID)
-		if err == nil {
-			t.Fatalf("expected error getting application")
-		}
 	}
 }
 
@@ -483,290 +509,502 @@ func TestCredentialReadProviderError(t *testing.T) {
 	}
 }
 
-// TestCredentialInteg is an integration test against the live Azure service. It requires
+// TestRoleAssignmentWALRollback tests rolling back any
+// role assignments that may have taken place prior to
+// a subsequent failure resulting in the need to rollback
+// an App or SP. This test requires valid, sufficiently-privileged
+// Azure credentials in env variables.
+func TestRoleAssignmentWALRollback(t *testing.T) {
+if os.Getenv("VAULT_ACC") != "1" {
+    t.SkipNow()
+}
+
+if os.Getenv("AZURE_CLIENT_SECRET") == "" {
+    t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
+}
+
+t.Run("service principals", func(t *testing.T) {
+    t.Parallel()
+
+    skipIfMissingEnvVars(t,
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+        "AZURE_TEST_RESOURCE_GROUP",
+    )
+
+    b := backend()
+    s := new(logical.InmemStorage)
+    subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+    clientID := os.Getenv("AZURE_CLIENT_ID")
+    clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+    tenantID := os.Getenv("AZURE_TENANT_ID")
+    resourceGroup := os.Getenv("AZURE_TEST_RESOURCE_GROUP")
+
+    config := &logical.BackendConfig{
+        Logger: logging.NewVaultLogger(log.Trace),
+        System: &logical.StaticSystemView{
+            DefaultLeaseTTLVal: defaultLeaseTTLHr,
+            MaxLeaseTTLVal:     maxLeaseTTLHr,
+        },
+        StorageView: s,
+    }
+    err := b.Setup(context.Background(), config)
+    assertErrorIsNil(t, err)
+
+    configData := map[string]interface{}{
+        "subscription_id": subscriptionID,
+        "client_id":       clientID,
+        "client_secret":   clientSecret,
+        "tenant_id":       tenantID,
+    }
+
+    configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      "config",
+        Data:      configData,
+        Storage:   s,
+    })
+    assertRespNoError(t, configResp, err)
+
+    roleName := "test_role_rawalrollback"
+
+    roleData := map[string]interface{}{
+        "azure_roles": fmt.Sprintf(`[
+        {
+            "role_name": "Storage Blob Data Owner",
+            "scope":  "/subscriptions/%s/resourceGroups/%s"
+        },
+        {
+            "role_name": "Reader",
+            "scope":  "/subscriptions/%s/resourceGroups/%s"
+        }]`, subscriptionID, resourceGroup, subscriptionID, resourceGroup),
+    }
+
+    roleResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      fmt.Sprintf("roles/%s", roleName),
+        Data:      roleData,
+        Storage:   s,
+    })
+    assertRespNoError(t, roleResp, err)
+
+    credsResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.ReadOperation,
+        Path:      fmt.Sprintf("creds/%s", roleName),
+        Storage:   s,
+    })
+    assertRespNoError(t, credsResp, err)
+
+    appID := credsResp.Data["client_id"].(string)
+
+    // Use the underlying provider to access clients directly for testing
+    client, err := b.getClient(context.Background(), s)
+    assertErrorIsNil(t, err)
+    provider := client.provider.(*provider)
+    spObjID := findServicePrincipalID(t, provider.spClient, appID)
+
+    assertServicePrincipalExists(t, provider.spClient, spObjID)
+
+    // Verify that the role assignments were created. Get the assignment
+    // info from Azure and verify it matches the Reader role.
+    raIDs := credsResp.Secret.InternalData["role_assignment_ids"].([]string)
+    equal(t, 2, len(raIDs))
+
+    ra, err := provider.raClient.GetByID(context.Background(), raIDs[0])
+    assertErrorIsNil(t, err)
+
+    roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
+    assertErrorIsNil(t, err)
+
+    defID := *ra.RoleAssignmentPropertiesWithScope.RoleDefinitionID
+    found := false
+    for _, def := range roleDefs {
+        if *def.ID == defID && *def.RoleName == "Storage Blob Data Owner" {
+            found = true
+            break
+        }
+    }
+
+    if !found {
+        t.Fatal("'Storage Blob Data Owner' role assignment not found")
+    }
+
+    // Parse the assignment IDs
+    var assignmentIDs []string
+    for _, raID := range raIDs {
+        t := strings.Split(raID, "/")
+        tRa := t[len(t)-1]
+        assignmentIDs = append(assignmentIDs, strings.Replace(tRa, " ", "", -1))
+    }
+
+    // Remove one of the RA IDs to simulate a failure to assign a role
+    if err := client.unassignRoles(context.Background(), []string{raIDs[0]}); err != nil {
+        t.Fatalf("error unassigning Role: %s", err.Error())
+    }
+
+    rEntry, err := s.Get(context.Background(), fmt.Sprintf("%s/%s", "roles", roleName))
+    if err != nil {
+        t.Fatalf("error getting role from storage: %s", err.Error())
+    }
+
+    if rEntry == nil {
+        t.Fatalf("role entry was nil: %s", err.Error())
+    }
+
+    // Decode returned Role Entry
+    role := new(roleEntry)
+    if err := rEntry.DecodeJSON(role); err != nil {
+        t.Fatalf("unable to decode role entry: %s", err.Error())
+    }
+
+    // Manually Create Role Assignment WAL
+    rWALID, err := framework.PutWAL(context.Background(), s, walAppRoleAssignment, &walAppRoleAssign{
+        SpID:          spObjID,
+        AssignmentIDs: assignmentIDs,
+        AzureRoles:    role.AzureRoles,
+        Expiration:    time.Now().Add(maxWALAge),
+    })
+    if err != nil {
+        t.Fatalf("error creating role assignment WAL: %s", err.Error())
+    }
+
+    // Retrieve WAL
+    entry, err := framework.GetWAL(context.Background(), s, rWALID)
+    if err != nil {
+        t.Fatalf("error retrieving role assignment WAL: %s", err.Error())
+    }
+
+    // Decode the WAL data
+    var appRoleAssign walAppRoleAssign
+    d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+        DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+        Result:     &appRoleAssign,
+    })
+    if err != nil {
+        t.Fatalf("error decoding WAL data: %s", err.Error())
+    }
+    err = d.Decode(entry.Data)
+    if err != nil {
+        t.Fatalf("error decoding WAL data: %s", err.Error())
+    }
+
+    req := &logical.Request{
+        Storage: s,
+    }
+
+    // Initiate Role Assignment Rollback
+    err = b.walRollback(context.Background(), req, entry.Kind, entry.Data)
+    if err != nil {
+        t.Fatalf("error rolling back WAL: %s", err.Error())
+    }
+
+    // Serialize and deserialize the secret to remove typing, as will really happen.
+    fakeSaveLoad(credsResp.Secret)
+
+    // Revoke the Service Principal by sending back the secret we just received
+    req = &logical.Request{
+        Secret:  credsResp.Secret,
+        Storage: s,
+    }
+
+    _, err = b.spRevoke(context.Background(), req, nil)
+    if err != nil {
+        t.Fatalf("error revoking service principal: %s", err.Error())
+    }
+
+    // Verify that SP get is an error after delete. Expected there
+    // to be a delay and that this step would take some time/retries,
+    // but that seems not to be the case.
+    assertServicePrincipalDoesNotExist(t, provider.spClient, spObjID)
+})
+}
+
+// This is an integration test against the live Azure service. It requires
 // valid, sufficiently-privileged Azure credentials in env variables.
 func TestCredentialInteg_aad(t *testing.T) {
-	if os.Getenv("VAULT_ACC") != "1" {
-		t.SkipNow()
-	}
+if os.Getenv("VAULT_ACC") != "1" {
+    t.SkipNow()
+}
 
-	if os.Getenv("AZURE_CLIENT_SECRET") == "" {
-		t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
-	}
+if os.Getenv("AZURE_CLIENT_SECRET") == "" {
+    t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
+}
 
-	t.Run("service principals", func(t *testing.T) {
-		t.Parallel()
+t.Run("service principals", func(t *testing.T) {
+    t.Parallel()
 
-		skipIfMissingEnvVars(t,
-			"AZURE_SUBSCRIPTION_ID",
-			"AZURE_CLIENT_ID",
-			"AZURE_CLIENT_SECRET",
-			"AZURE_TENANT_ID",
-		)
+    skipIfMissingEnvVars(t,
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+    )
 
-		b := backend()
-		s := new(logical.InmemStorage)
-		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
-		clientID := os.Getenv("AZURE_CLIENT_ID")
-		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-		tenantID := os.Getenv("AZURE_TENANT_ID")
+    b := backend()
+    s := new(logical.InmemStorage)
+    subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+    clientID := os.Getenv("AZURE_CLIENT_ID")
+    clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+    tenantID := os.Getenv("AZURE_TENANT_ID")
 
-		config := &logical.BackendConfig{
-			Logger: logging.NewVaultLogger(log.Trace),
-			System: &logical.StaticSystemView{
-				DefaultLeaseTTLVal: defaultLeaseTTLHr,
-				MaxLeaseTTLVal:     maxLeaseTTLHr,
-			},
-			StorageView: s,
-		}
-		err := b.Setup(context.Background(), config)
-		assertErrorIsNil(t, err)
+    config := &logical.BackendConfig{
+        Logger: logging.NewVaultLogger(log.Trace),
+        System: &logical.StaticSystemView{
+            DefaultLeaseTTLVal: defaultLeaseTTLHr,
+            MaxLeaseTTLVal:     maxLeaseTTLHr,
+        },
+        StorageView: s,
+    }
+    err := b.Setup(context.Background(), config)
+    assertErrorIsNil(t, err)
 
-		configData := map[string]interface{}{
-			"subscription_id":         subscriptionID,
-			"client_id":               clientID,
-			"client_secret":           clientSecret,
-			"tenant_id":               tenantID,
-			"use_microsoft_graph_api": false,
-		}
+    configData := map[string]interface{}{
+        "subscription_id":         subscriptionID,
+        "client_id":               clientID,
+        "client_secret":           clientSecret,
+        "tenant_id":               tenantID,
+        "use_microsoft_graph_api": false,
+    }
 
-		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      "config",
-			Data:      configData,
-			Storage:   s,
-		})
-		assertRespNoError(t, configResp, err)
+    configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      "config",
+        Data:      configData,
+        Storage:   s,
+    })
+    assertRespNoError(t, configResp, err)
 
-		// Add a Vault role that will provide creds with Azure "Reader" permissions
-		// Resources groups "vault-azure-secrets-test1" and "vault-azure-secrets-test2"
-		// should already exist in the test infrastructure. (The test can be simplified
-		// to just use scope "/subscriptions/%s" if need be.)
-		rolename := "test_role"
-		role := map[string]interface{}{
-			"azure_roles": fmt.Sprintf(`[
-			{
-				"role_name": "Reader",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
-			},
-			{
-				"role_name": "Reader",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
-			}]`, subscriptionID, subscriptionID),
-		}
-		resp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      fmt.Sprintf("roles/%s", rolename),
-			Data:      role,
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    // Add a Vault role that will provide creds with Azure "Reader" permissions
+    // Resources groups "vault-azure-secrets-test1" and "vault-azure-secrets-test2"
+    // should already exist in the test infrastructure. (The test can be simplified
+    // to just use scope "/subscriptions/%s" if need be.)
+    rolename := "test_role"
+    role := map[string]interface{}{
+        "azure_roles": fmt.Sprintf(`[
+        {
+            "role_name": "Reader",
+            "scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
+        },
+        {
+            "role_name": "Reader",
+            "scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
+        }]`, subscriptionID, subscriptionID),
+    }
+    resp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      fmt.Sprintf("roles/%s", rolename),
+        Data:      role,
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		// Request credentials
-		resp, err = b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      fmt.Sprintf("creds/%s", rolename),
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    // Request credentials
+    resp, err = b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.ReadOperation,
+        Path:      fmt.Sprintf("creds/%s", rolename),
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		appID := resp.Data["client_id"].(string)
+    appID := resp.Data["client_id"].(string)
 
-		// Use the underlying provider to access clients directly for testing
-		client, err := b.getClient(context.Background(), s)
-		assertErrorIsNil(t, err)
-		provider := client.provider.(*provider)
-		spObjID := findServicePrincipalID(t, provider.spClient, appID)
+    // Use the underlying provider to access clients directly for testing
+    client, err := b.getClient(context.Background(), s)
+    assertErrorIsNil(t, err)
+    provider := client.provider.(*provider)
+    spObjID := findServicePrincipalID(t, provider.spClient, appID)
 
-		assertServicePrincipalExists(t, provider.spClient, spObjID)
+    assertServicePrincipalExists(t, provider.spClient, spObjID)
 
-		// Verify that the role assignments were created. Get the assignment
-		// info from Azure and verify it matches the Reader role.
-		raIDs := resp.Secret.InternalData["role_assignment_ids"].([]string)
-		equal(t, 2, len(raIDs))
+    // Verify that the role assignments were created. Get the assignment
+    // info from Azure and verify it matches the Reader role.
+    raIDs := resp.Secret.InternalData["role_assignment_ids"].([]string)
+    equal(t, 2, len(raIDs))
 
-		ra, err := provider.raClient.GetByID(context.Background(), raIDs[0])
-		assertErrorIsNil(t, err)
+    ra, err := provider.raClient.GetByID(context.Background(), raIDs[0])
+    assertErrorIsNil(t, err)
 
-		roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
-		assertErrorIsNil(t, err)
+    roleDefs, err := provider.ListRoleDefinitions(context.Background(), fmt.Sprintf("subscriptions/%s", subscriptionID), "")
+    assertErrorIsNil(t, err)
 
-		defID := *ra.RoleAssignmentPropertiesWithScope.RoleDefinitionID
-		found := false
-		for _, def := range roleDefs {
-			if *def.ID == defID && *def.RoleName == "Reader" {
-				found = true
-				break
-			}
-		}
+    defID := *ra.RoleAssignmentPropertiesWithScope.RoleDefinitionID
+    found := false
+    for _, def := range roleDefs {
+        if *def.ID == defID && *def.RoleName == "Reader" {
+            found = true
+            break
+        }
+    }
 
-		if !found {
-			t.Fatal("'Reader' role assignment not found")
-		}
+    if !found {
+        t.Fatal("'Reader' role assignment not found")
+    }
 
-		// Serialize and deserialize the secret to remove typing, as will really happen.
-		fakeSaveLoad(resp.Secret)
+    // Serialize and deserialize the secret to remove typing, as will really happen.
+    fakeSaveLoad(resp.Secret)
 
-		// Revoke the Service Principal by sending back the secret we just received
-		req := &logical.Request{
-			Secret:  resp.Secret,
-			Storage: s,
-		}
+    // Revoke the Service Principal by sending back the secret we just received
+    req := &logical.Request{
+        Secret:  resp.Secret,
+        Storage: s,
+    }
 
-		b.spRevoke(context.Background(), req, nil)
+    b.spRevoke(context.Background(), req, nil)
 
-		// Verify that SP get is an error after delete. Expected there
-		// to be a delay and that this step would take some time/retries,
-		// but that seems not to be the case.
-		assertServicePrincipalDoesNotExist(t, provider.spClient, spObjID)
-	})
+    // Verify that SP get is an error after delete. Expected there
+    // to be a delay and that this step would take some time/retries,
+    // but that seems not to be the case.
+    assertServicePrincipalDoesNotExist(t, provider.spClient, spObjID)
+})
 
-	t.Run("static service principals", func(t *testing.T) {
-		t.Parallel()
+t.Run("static service principals", func(t *testing.T) {
+    t.Parallel()
 
-		skipIfMissingEnvVars(t,
-			"AZURE_SUBSCRIPTION_ID",
-			"AZURE_CLIENT_ID",
-			"AZURE_CLIENT_SECRET",
-			"AZURE_TENANT_ID",
-		)
+    skipIfMissingEnvVars(t,
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+    )
 
-		b := backend()
-		s := new(logical.InmemStorage)
-		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
-		clientID := os.Getenv("AZURE_CLIENT_ID")
-		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-		tenantID := os.Getenv("AZURE_TENANT_ID")
+    b := backend()
+    s := new(logical.InmemStorage)
+    subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+    clientID := os.Getenv("AZURE_CLIENT_ID")
+    clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+    tenantID := os.Getenv("AZURE_TENANT_ID")
 
-		config := &logical.BackendConfig{
-			Logger: logging.NewVaultLogger(log.Trace),
-			System: &logical.StaticSystemView{
-				DefaultLeaseTTLVal: defaultLeaseTTLHr,
-				MaxLeaseTTLVal:     maxLeaseTTLHr,
-			},
-			StorageView: s,
-		}
-		err := b.Setup(context.Background(), config)
-		assertErrorIsNil(t, err)
+    config := &logical.BackendConfig{
+        Logger: logging.NewVaultLogger(log.Trace),
+        System: &logical.StaticSystemView{
+            DefaultLeaseTTLVal: defaultLeaseTTLHr,
+            MaxLeaseTTLVal:     maxLeaseTTLHr,
+        },
+        StorageView: s,
+    }
+    err := b.Setup(context.Background(), config)
+    assertErrorIsNil(t, err)
 
-		configData := map[string]interface{}{
-			"subscription_id":         subscriptionID,
-			"client_id":               clientID,
-			"client_secret":           clientSecret,
-			"tenant_id":               tenantID,
-			"use_microsoft_graph_api": false,
-		}
+    configData := map[string]interface{}{
+        "subscription_id":         subscriptionID,
+        "client_id":               clientID,
+        "client_secret":           clientSecret,
+        "tenant_id":               tenantID,
+        "use_microsoft_graph_api": false,
+    }
 
-		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      "config",
-			Data:      configData,
-			Storage:   s,
-		})
-		assertRespNoError(t, configResp, err)
+    configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      "config",
+        Data:      configData,
+        Storage:   s,
+    })
+    assertRespNoError(t, configResp, err)
 
-		rolename := "static_test_role"
-		role := map[string]interface{}{
-			"azure_roles": fmt.Sprintf(`[{
-			"role_name": "Reader",
-			"scope":  "/subscriptions/%s"
-		}]`, subscriptionID),
-		}
-		resp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      fmt.Sprintf("roles/%s", rolename),
-			Data:      role,
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    rolename := "static_test_role"
+    role := map[string]interface{}{
+        "azure_roles": fmt.Sprintf(`[{
+        "role_name": "Reader",
+        "scope":  "/subscriptions/%s"
+    }]`, subscriptionID),
+    }
+    resp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      fmt.Sprintf("roles/%s", rolename),
+        Data:      role,
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		// Request credentials
-		resp, err = b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      fmt.Sprintf("creds/%s", rolename),
-			Data:      role,
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    // Request credentials
+    resp, err = b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.ReadOperation,
+        Path:      fmt.Sprintf("creds/%s", rolename),
+        Data:      role,
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		origResp := resp
+    origResp := resp
 
-		appObjID := resp.Secret.InternalData["app_object_id"].(string)
-		appID := resp.Data["client_id"].(string)
+    appObjID := resp.Secret.InternalData["app_object_id"].(string)
+    appID := resp.Data["client_id"].(string)
 
-		// Create a new role that will add passwords to the previously
-		// created application when creds are requested.
+    // Create a new role that will add passwords to the previously
+    // created application when creds are requested.
 
-		rolename = "test_role2"
-		role = map[string]interface{}{
-			"application_object_id": appObjID,
-		}
-		resp, err = b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      fmt.Sprintf("roles/%s", rolename),
-			Data:      role,
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    rolename = "test_role2"
+    role = map[string]interface{}{
+        "application_object_id": appObjID,
+    }
+    resp, err = b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      fmt.Sprintf("roles/%s", rolename),
+        Data:      role,
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		// Request credentials
-		resp, err = b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      fmt.Sprintf("creds/%s", rolename),
-			Data:      role,
-			Storage:   s,
-		})
-		assertRespNoError(t, resp, err)
+    // Request credentials
+    resp, err = b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.ReadOperation,
+        Path:      fmt.Sprintf("creds/%s", rolename),
+        Data:      role,
+        Storage:   s,
+    })
+    assertRespNoError(t, resp, err)
 
-		// Test the added password by creating a new Azure provider with these
-		// creds and attempting an operation with it.
-		clientConfig := azureConfig{}
+    // Test the added password by creating a new Azure provider with these
+    // creds and attempting an operation with it.
+    clientConfig := azureConfig{}
 
-		settings, err := b.getClientSettings(context.Background(), &clientConfig)
-		if err != nil {
-			t.Fatal(err)
-		}
+    settings, err := b.getClientSettings(context.Background(), &clientConfig)
+    if err != nil {
+        t.Fatal(err)
+    }
 
-		settings.ClientID = appID
-		settings.ClientSecret = resp.Data["client_secret"].(string)
+    settings.ClientID = appID
+    settings.ClientSecret = resp.Data["client_secret"].(string)
 
-		success := false
+    success := false
 
-		// The new app may not be propagated immediately, so retry for ~30s.
-		for i := 0; i < 8; i++ {
-			// New credentials are only tested during an actual operation, not provider creation.
-			// This step should never fail.
-			p, err := newAzureProvider(settings, true, api.Passwords{})
-			if err != nil {
-				t.Fatal(err)
-			}
+    // The new app may not be propagated immediately, so retry for ~30s.
+    for i := 0; i < 8; i++ {
+        // New credentials are only tested during an actual operation, not provider creation.
+        // This step should never fail.
+        p, err := newAzureProvider(settings, true, api.Passwords{})
+        if err != nil {
+            t.Fatal(err)
+        }
 
-			_, err = p.GetApplication(context.Background(), appObjID)
-			if err == nil {
-				success = true
-				break
-			}
-			time.Sleep(5 * time.Second)
-		}
+        _, err = p.GetApplication(context.Background(), appObjID)
+        if err == nil {
+            success = true
+            break
+        }
+        time.Sleep(5 * time.Second)
+    }
 
-		if !success {
-			t.Fatalf("unable to validate with credentials. Last error: %v", err)
-		}
+    if !success {
+        t.Fatalf("unable to validate with credentials. Last error: %v", err)
+    }
 
-		// Serialize and deserialize the secret to remove typing, as will really happen.
-		fakeSaveLoad(origResp.Secret)
+    // Serialize and deserialize the secret to remove typing, as will really happen.
+    fakeSaveLoad(origResp.Secret)
 
-		// Revoke the Service Principal by sending back the secret we just received
-		req := &logical.Request{
-			Secret:  origResp.Secret,
-			Storage: s,
-		}
+    // Revoke the Service Principal by sending back the secret we just received
+    req := &logical.Request{
+        Secret:  origResp.Secret,
+        Storage: s,
+    }
 
-		_, err = b.spRevoke(context.Background(), req, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+    _, err = b.spRevoke(context.Background(), req, nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+})
 }
 
 // Similar to TestCredentialInteg, this is an integration test against the live Azure service. It requires
@@ -774,88 +1012,88 @@ func TestCredentialInteg_aad(t *testing.T) {
 // The credentials provided to this must include permissions to use MS Graph and not AAD
 // Unfortunately this means that this test cannot be run within the same test execution as TestCredentialInteg
 func TestCredentialInteg_msgraph(t *testing.T) {
-	if os.Getenv("VAULT_ACC") != "1" {
-		t.SkipNow()
-	}
+if os.Getenv("VAULT_ACC") != "1" {
+    t.SkipNow()
+}
 
-	if os.Getenv("AZURE_CLIENT_SECRET") == "" {
-		t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
-	}
+if os.Getenv("AZURE_CLIENT_SECRET") == "" {
+    t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
+}
 
-	t.Run("service principals", func(t *testing.T) {
-		t.Parallel()
+t.Run("service principals", func(t *testing.T) {
+    t.Parallel()
 
-		skipIfMissingEnvVars(t,
-			"AZURE_SUBSCRIPTION_ID",
-			"AZURE_CLIENT_ID",
-			"AZURE_CLIENT_SECRET",
-			"AZURE_TENANT_ID",
-		)
+    skipIfMissingEnvVars(t,
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+    )
 
-		b := backend()
-		s := new(logical.InmemStorage)
-		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
-		clientID := os.Getenv("AZURE_CLIENT_ID")
-		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-		tenantID := os.Getenv("AZURE_TENANT_ID")
+    b := backend()
+    s := new(logical.InmemStorage)
+    subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+    clientID := os.Getenv("AZURE_CLIENT_ID")
+    clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+    tenantID := os.Getenv("AZURE_TENANT_ID")
 
-		config := &logical.BackendConfig{
-			Logger: logging.NewVaultLogger(log.Trace),
-			System: &logical.StaticSystemView{
-				DefaultLeaseTTLVal: defaultLeaseTTLHr,
-				MaxLeaseTTLVal:     maxLeaseTTLHr,
-			},
-			StorageView: s,
-		}
-		err := b.Setup(context.Background(), config)
-		assertErrorIsNil(t, err)
+    config := &logical.BackendConfig{
+        Logger: logging.NewVaultLogger(log.Trace),
+        System: &logical.StaticSystemView{
+            DefaultLeaseTTLVal: defaultLeaseTTLHr,
+            MaxLeaseTTLVal:     maxLeaseTTLHr,
+        },
+        StorageView: s,
+    }
+    err := b.Setup(context.Background(), config)
+    assertErrorIsNil(t, err)
 
-		configData := map[string]interface{}{
-			"subscription_id":         subscriptionID,
-			"client_id":               clientID,
-			"client_secret":           clientSecret,
-			"tenant_id":               tenantID,
-			"use_microsoft_graph_api": true,
-		}
+    configData := map[string]interface{}{
+        "subscription_id":         subscriptionID,
+        "client_id":               clientID,
+        "client_secret":           clientSecret,
+        "tenant_id":               tenantID,
+        "use_microsoft_graph_api": true,
+    }
 
-		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      "config",
-			Data:      configData,
-			Storage:   s,
-		})
-		assertRespNoError(t, configResp, err)
+    configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      "config",
+        Data:      configData,
+        Storage:   s,
+    )
+    assertRespNoError(t, configResp, err)
 
-		roleName := "test_role_msgraph"
+    roleName := "test_role_msgraph"
 
-		roleData := map[string]interface{}{
-			"azure_roles": fmt.Sprintf(`[
-			{
-				"role_name": "Storage Blob Data Owner",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
-			},
-			{
-				"role_name": "Reader",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
-			}]`, subscriptionID, subscriptionID),
-		}
+    roleData := map[string]interface{}{
+        "azure_roles": fmt.Sprintf(`[
+        {
+            "role_name": "Storage Blob Data Owner",
+            "scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
+        },
+        {
+            "role_name": "Reader",
+            "scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
+        }]`, subscriptionID, subscriptionID),
+    }
 
-		roleResp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.CreateOperation,
-			Path:      fmt.Sprintf("roles/%s", roleName),
-			Data:      roleData,
-			Storage:   s,
-		})
-		assertRespNoError(t, roleResp, err)
+    roleResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.CreateOperation,
+        Path:      fmt.Sprintf("roles/%s", roleName),
+        Data:      roleData,
+        Storage:   s,
+    })
+    assertRespNoError(t, roleResp, err)
 
-		credsResp, err := b.HandleRequest(context.Background(), &logical.Request{
-			Operation: logical.ReadOperation,
-			Path:      fmt.Sprintf("creds/%s", roleName),
-			Storage:   s,
-		})
-		assertRespNoError(t, credsResp, err)
+    credsResp, err := b.HandleRequest(context.Background(), &logical.Request{
+        Operation: logical.ReadOperation,
+        Path:      fmt.Sprintf("creds/%s", roleName),
+        Storage:   s,
+    })
+    assertRespNoError(t, credsResp, err)
 
-		appID := credsResp.Data["client_id"].(string)
+appID := credsResp.Data["client_id"].(string)
 
 		// Use the underlying provider to access clients directly for testing
 		client, err := b.getClient(context.Background(), s)

--- a/wal.go
+++ b/wal.go
@@ -3,15 +3,18 @@ package azuresecrets
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
 )
 
 const (
-	walAppKey          = "appCreate"
-	walRotateRootCreds = "rotateRootCreds"
+	walAppKey            = "appCreate"
+	walRotateRootCreds   = "rotateRootCreds"
+	walAppRoleAssignment = "appRoleAssign"
 )
 
 // Eventually expire the WAL if for some reason the rollback operation consistently fails
@@ -23,6 +26,8 @@ func (b *azureSecretBackend) walRollback(ctx context.Context, req *logical.Reque
 		return b.rollbackAppWAL(ctx, req, data)
 	case walRotateRootCreds:
 		return b.rollbackRootWAL(ctx, req, data)
+	case walAppRoleAssignment:
+		return b.rollbackRoleAssignWAL(ctx, req, data)
 	default:
 		return fmt.Errorf("unknown rollback type %q", kind)
 	}
@@ -64,6 +69,7 @@ func (b *azureSecretBackend) rollbackAppWAL(ctx context.Context, req *logical.Re
 		b.Logger().Warn("rollback error deleting App", "err", err)
 
 		if time.Now().After(entry.Expiration) {
+			b.Logger().Warn("app WAL expired prior to rollback; resources may still exist")
 			return nil
 		}
 		return err
@@ -93,5 +99,71 @@ func (b *azureSecretBackend) rollbackRootWAL(ctx context.Context, req *logical.R
 
 	b.updatePassword = false
 
+	return nil
+}
+
+type walAppRoleAssign struct {
+	SpID          string
+	AssignmentIDs []string
+	AzureRoles    []*AzureRole
+	Expiration    time.Time
+}
+
+func (b *azureSecretBackend) rollbackRoleAssignWAL(ctx context.Context, req *logical.Request, data interface{}) error {
+	// Decode the WAL data
+	var entry walAppRoleAssign
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+		Result:     &entry,
+	})
+	if err != nil {
+		return err
+	}
+	err = d.Decode(data)
+	if err != nil {
+		return err
+	}
+
+	client, err := b.getClient(ctx, req.Storage)
+	if err != nil {
+		return err
+	}
+
+	b.Logger().Debug("rolling back role assignments for service principal", "ID", entry.SpID)
+
+	// Return if there aren't any roles to unassign
+	if entry.AzureRoles == nil {
+		b.Logger().Error("no azure roles associated with role")
+		return nil
+	}
+
+	// Assemble all App Role Assignment IDs
+	var roleAssignments []string
+	for i, assignmentID := range entry.AssignmentIDs {
+		if entry.AzureRoles[i] == nil {
+			return fmt.Errorf("azure role was nil")
+		}
+		roleAssignments = append(roleAssignments, fmt.Sprintf("%s/providers/Microsoft.Authorization/roleAssignments/%s",
+			entry.AzureRoles[i].Scope,
+			assignmentID))
+	}
+
+	// Check any errors to filter out expected responses. Azure will return
+	// a 204 when trying to delete a role assignment that has already been
+	// deleted, or does not exist. We may hit this case during rollback.
+	if err := client.unassignRoles(ctx, roleAssignments); err != nil {
+		for _, e := range err.(*multierror.Error).Errors {
+			switch {
+			case strings.Contains(e.Error(), "StatusCode=204"):
+				b.Logger().Trace("role assignment already deleted or does not exist", "err", e.Error())
+			default:
+				return fmt.Errorf("rollback error unassinging role: %w", e)
+			}
+		}
+		if time.Now().After(entry.Expiration) {
+			b.Logger().Warn("role assignment WAL expired prior to rollback; resources may still exist")
+			return nil
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
* Implement Role Assignment WAL and rollback

* Improve error handling around unassignment of non-existent role assignment ID

* Better error handling in test, and guarding against nil or empty values

* Add clarity to rollback log message, and check if there were no Azure Roles associated with Role

* Further improve error handling, fix failing test, add guard against size mismatch between number of roles and assignmentIDs, parameterize Resource Group in test

* Fix rollback test, and clean up left over debug line

* Add missing error check for spRevoke during test, use errors.New instead of Errorf for AzureRoles and assignmentIDs check

* Add warning about resources potentially still existing if WAL has expired

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
