### PR TITLE
Backport 1.12: Implement WAL rollback mechanism for Role Assignments (#110)

### DIFF
--- a/wal.go
+++ b/wal.go
@@ -3,15 +3,18 @@ package azuresecrets
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
 )
 
 const (
-	walAppKey          = "appCreate"
-	walRotateRootCreds = "rotateRootCreds"
+	walAppKey            = "appCreate"
+	walRotateRootCreds   = "rotateRootCreds"
+	walAppRoleAssignment = "appRoleAssign"
 )
 
 // Eventually expire the WAL if for some reason the rollback operation consistently fails
@@ -23,6 +26,8 @@ func (b *azureSecretBackend) walRollback(ctx context.Context, req *logical.Reque
 		return b.rollbackAppWAL(ctx, req, data)
 	case walRotateRootCreds:
 		return b.rollbackRootWAL(ctx, req, data)
+	case walAppRoleAssignment:
+		return b.rollbackRoleAssignWAL(ctx, req, data)
 	default:
 		return fmt.Errorf("unknown rollback type %q", kind)
 	}
@@ -64,6 +69,7 @@ func (b *azureSecretBackend) rollbackAppWAL(ctx context.Context, req *logical.Re
 		b.Logger().Warn("rollback error deleting App", "err", err)
 
 		if time.Now().After(entry.Expiration) {
+			b.Logger().Warn("app WAL expired prior to rollback; resources may still exist")
 			return nil
 		}
 		return err
@@ -93,5 +99,71 @@ func (b *azureSecretBackend) rollbackRootWAL(ctx context.Context, req *logical.R
 
 	b.updatePassword = false
 
+	return nil
+}
+
+type walAppRoleAssign struct {
+	SpID          string
+	AssignmentIDs []string
+	AzureRoles    []*AzureRole
+	Expiration    time.Time
+}
+
+func (b *azureSecretBackend) rollbackRoleAssignWAL(ctx context.Context, req *logical.Request, data interface{}) error {
+	// Decode the WAL data
+	var entry walAppRoleAssign
+	d, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+		Result:     &entry,
+	})
+	if err != nil {
+		return err
+	}
+	err = d.Decode(data)
+	if err != nil {
+		return err
+	}
+
+	client, err := b.getClient(ctx, req.Storage)
+	if err != nil {
+		return err
+	}
+
+	b.Logger().Debug("rolling back role assignments for service principal", "ID", entry.SpID)
+
+	// Return if there aren't any roles to unassign
+	if entry.AzureRoles == nil {
+		b.Logger().Error("no azure roles associated with role")
+		return nil
+	}
+
+	// Assemble all App Role Assignment IDs
+	var roleAssignments []string
+	for i, assignmentID := range entry.AssignmentIDs {
+		if entry.AzureRoles[i] == nil {
+			return fmt.Errorf("azure role was nil")
+		}
+		roleAssignments = append(roleAssignments, fmt.Sprintf("%s/providers/Microsoft.Authorization/roleAssignments/%s",
+			entry.AzureRoles[i].Scope,
+			assignmentID))
+	}
+
+	// Check any errors to filter out expected responses. Azure will return
+	// a 204 when trying to delete a role assignment that has already been
+	// deleted, or does not exist. We may hit this case during rollback.
+	if err := client.unassignRoles(ctx, roleAssignments); err != nil {
+		for _, e := range err.(*multierror.Error).Errors {
+			switch {
+			case strings.Contains(e.Error(), "StatusCode=204"):
+				b.Logger().Trace("role assignment already deleted or does not exist", "err", e.Error())
+			default:
+				return fmt.Errorf("rollback error unassinging role: %w", e)
+			}
+		}
+		if time.Now().After(entry.Expiration) {
+			b.Logger().Warn("role assignment WAL expired prior to rollback; resources may still exist")
+			return nil
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
* Implement Role Assignment WAL and rollback

* Improve error handling around unassignment of non-existent role assignment ID

* Better error handling in test, and guarding against nil or empty values

* Add clarity to rollback log message, and check if there were no Azure Roles associated with Role

* Further improve error handling, fix failing test, add guard against size mismatch between number of roles and assignmentIDs, parameterize Resource Group in test

* Fix rollback test, and clean up left over debug line

* Add missing error check for spRevoke during test, use errors.New instead of Errorf for AzureRoles and assignmentIDs check

* Add warning about resources potentially still existing if WAL has expired

# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
What is the change? 
Why is the change needed?
How does this change affect the user experience (if at all)?

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
