### PR TITLE
Fix: Use correct function signature when assigning roles

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,10 +14,11 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
-	multierror "github.com/hashicorp/go-multierror"
-	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/vault-plugin-secrets-azure/api"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/logical"
+
+	"github.com/hashicorp/vault-plugin-secrets-azure/api"
 )
 
 const (
@@ -139,6 +140,22 @@ func (c *client) deleteApp(ctx context.Context, appObjectID string, permanentlyD
 // deleteServicePrincipal deletes an Azure service principal.
 func (c *client) deleteServicePrincipal(ctx context.Context, spObjectID string, permanentlyDelete bool) error {
 	return c.provider.DeleteServicePrincipal(ctx, spObjectID, permanentlyDelete)
+}
+
+// generateAssignmentIDsFromRole pre-generates UUIDs to be
+// provided to assignRoles in case we need to rollback
+func (c *client) generateAssignmentIDsFromRole(role *roleEntry) ([]string, error) {
+	var assignmentIDs []string
+
+	for i := 0; i < len(role.AzureRoles); i++ {
+		assignmentID, err := uuid.GenerateUUID()
+		if err != nil {
+			return nil, err
+		}
+		assignmentIDs = append(assignmentIDs, assignmentID)
+	}
+
+	return assignmentIDs, nil
 }
 
 // assignRoles assigns Azure roles to a service principal.

--- a/client.go
+++ b/client.go
@@ -142,12 +142,12 @@ func (c *client) deleteServicePrincipal(ctx context.Context, spObjectID string, 
 	return c.provider.DeleteServicePrincipal(ctx, spObjectID, permanentlyDelete)
 }
 
-// generateAssignmentIDsFromRole pre-generates UUIDs to be
-// provided to assignRoles in case we need to rollback
-func (c *client) generateAssignmentIDsFromRole(role *roleEntry) ([]string, error) {
+// generateUUIDs pre-generates a list of UUIDs of a
+// certain length.
+func (c *client) generateUUIDs(length int) ([]string, error) {
 	var assignmentIDs []string
 
-	for i := 0; i < len(role.AzureRoles); i++ {
+	for i := 0; i < length; i++ {
 		assignmentID, err := uuid.GenerateUUID()
 		if err != nil {
 			return nil, err

--- a/path_roles.go
+++ b/path_roles.go
@@ -345,13 +345,18 @@ func (b *azureSecretBackend) createPersistedApp(ctx context.Context, req *logica
 		return err
 	}
 
+	assignmentIDs, err := c.generateAssignmentIDsFromRole(role)
+	if err != nil {
+		return err
+	}
+
 	if role.ManagedApplicationObjectID != "" {
 		removeRolesAndGroupMembership(ctx, c, role)
 
 		spObjID := role.ServicePrincipalObjectID
 
 		// Assign Azure roles to the new SP
-		raIDs, err := c.assignRoles(ctx, spObjID, role.AzureRoles)
+		raIDs, err := c.assignRoles(ctx, spObjID, role.AzureRoles, assignmentIDs)
 		if err != nil {
 			return err
 		}
@@ -390,7 +395,7 @@ func (b *azureSecretBackend) createPersistedApp(ctx context.Context, req *logica
 	role.ServicePrincipalObjectID = spObjID
 
 	// Assign Azure roles to the new SP
-	raIDs, err := c.assignRoles(ctx, spObjID, role.AzureRoles)
+	raIDs, err := c.assignRoles(ctx, spObjID, role.AzureRoles, assignmentIDs)
 	if err != nil {
 		return err
 	}

--- a/path_roles.go
+++ b/path_roles.go
@@ -345,9 +345,9 @@ func (b *azureSecretBackend) createPersistedApp(ctx context.Context, req *logica
 		return err
 	}
 
-	assignmentIDs, err := c.generateAssignmentIDsFromRole(role)
+	assignmentIDs, err := c.generateUUIDs(len(role.AzureRoles))
 	if err != nil {
-		return err
+		return fmt.Errorf("error generating assginment IDs; err=%w", err)
 	}
 
 	if role.ManagedApplicationObjectID != "" {

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -121,9 +121,9 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 		return nil, err
 	}
 
-	assignmentIDs, err := c.generateAssignmentIDsFromRole(role)
+	assignmentIDs, err := c.generateUUIDs(len(role.AzureRoles))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error generating assginment IDs; err=%w", err)
 	}
 
 	// Write a second WAL entry in case the Role assignments don't complete

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -122,15 +121,9 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 		return nil, err
 	}
 
-	// Pre-generate UUIDs to be provided to assignRoles so we can rollback if we need to
-	var assignmentIDs []string
-
-	for i := 0; i < len(role.AzureRoles); i++ {
-		assignmentID, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, err
-		}
-		assignmentIDs = append(assignmentIDs, assignmentID)
+	assignmentIDs, err := c.generateAssignmentIDsFromRole(role)
+	if err != nil {
+		return nil, err
 	}
 
 	// Write a second WAL entry in case the Role assignments don't complete


### PR DESCRIPTION
This PR adds a fix for an incorrect usage of the `assignRoles` function (not passing any `assignmentIDs`). The function signature was updated around the same time this particular usage was merged, and hence it led to a bug.