### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+CHANGES:
+
+* Changes user-agent header value to use correct Vault version information and include
+  the plugin type and name in the comment section.
+
+IMPROVEMENTS:
+
 * Updated dependencies [[GH-109](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/109)]
     * `github.com/Azure/azure-sdk-for-go v67.0.0+incompatible`
     * `github.com/Azure/go-autorest/autorest v0.11.28`

--- a/backend.go
+++ b/backend.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+const userAgentPluginName = "secrets-azure"
+
 type azureSecretBackend struct {
 	*framework.Backend
 

--- a/client.go
+++ b/client.go
@@ -331,8 +331,7 @@ func (b *azureSecretBackend) getClientSettings(ctx context.Context, config *azur
 
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
-			"error", err)
+		return nil, fmt.Errorf("failed to read plugin environment: %w", err)
 	}
 	settings.PluginEnv = pluginEnv
 

--- a/client.go
+++ b/client.go
@@ -331,7 +331,8 @@ func (b *azureSecretBackend) getClientSettings(ctx context.Context, config *azur
 
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error loading plugin environment: %w", err)
+		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
+			"error", err)
 	}
 	settings.PluginEnv = pluginEnv
 

--- a/provider.go
+++ b/provider.go
@@ -29,7 +29,7 @@ type provider struct {
 // newAzureProvider creates an azureProvider, backed by Azure client objects for underlying services.
 func newAzureProvider(settings *clientSettings, passwords api.Passwords) (api.AzureProvider, error) {
 	// build clients that use the GraphRBAC endpoint
-	userAgent := getUserAgent(settings)
+	userAgent := useragent.PluginString(settings.PluginEnv, userAgentPluginName)
 
 	var appClient api.ApplicationsClient
 	var groupsClient api.GroupsClient
@@ -79,16 +79,6 @@ func newAzureProvider(settings *clientSettings, passwords api.Passwords) (api.Az
 	}
 
 	return p, nil
-}
-
-func getUserAgent(settings *clientSettings) string {
-	var userAgent string
-	if settings.PluginEnv != nil {
-		userAgent = useragent.PluginString(settings.PluginEnv, "azure-secrets")
-	} else {
-		userAgent = useragent.String()
-	}
-	return userAgent
 }
 
 // getAuthorizer attempts to create an authorizer, preferring ClientID/Secret if present,


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. Using `useragent.PluginString` will allow plugins running external to Vault to use correct Vault version information in construction of user-agent request headers regardless of the compiled SDK version.

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault/pull/14229
