### PR TITLE
Permanently delete app during WAL rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### IMPROVEMENTS:
 
+* permanently delete app during WAL rollback [GH-138](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/138)
 * enable plugin multiplexing [GH-134](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/134)
 * update dependencies
   * `github.com/hashicorp/vault/api` v1.9.0

--- a/wal.go
+++ b/wal.go
@@ -68,7 +68,7 @@ func (b *azureSecretBackend) rollbackAppWAL(ctx context.Context, req *logical.Re
 	// found, so no special handling is needed for that case. If we don't succeed within
 	// maxWALAge (e.g. client creds have changed and the delete will never succeed),
 	// unconditionally remove the WAL.
-	if err := client.deleteApp(ctx, entry.AppObjID, false); err != nil {
+	if err := client.deleteApp(ctx, entry.AppObjID, true); err != nil {
 		b.Logger().Warn("rollback error deleting App", "err", err)
 
 		if time.Now().After(entry.Expiration) {


### PR DESCRIPTION
# Overview
In the current form WAL rollback leaves apps in soft-deleted state which makes them still count towards tenant AD resource limit. As WAL rollback is supposed to cleanup when role assignment fails during dynamic SP creation it's alway guaranteed to have the App completely unused. With that it makes more sense to always permanently delete those apps on rollback, which is easily configurable in the current implementation.

# Design of Change
No real design, just changing to permanently delete apps during rollback instead of default soft-delete.

# Test Output
```
go test -v -run TestRoleAssignmentWALRollback
=== RUN   TestRoleAssignmentWALRollback
--- SKIP: TestRoleAssignmentWALRollback (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-azure	0.198s
```

# Related Issues/Pull Requests
https://github.com/hashicorp/vault-plugin-secrets-azure/pull/110
https://github.com/hashicorp/vault-plugin-secrets-azure/pull/104

