### PR TITLE
workflow/jira: use main ref for reusable gh action

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -8,7 +8,7 @@ on:
     types: [created]
 jobs:
   sync:
-    uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@f49ac86e61bf70e595c6b7d90b73cfb8378e0a16
+    uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main
     # assuming you use Vault to get secrets
     # if you use GitHub secrets, use secrets.XYZ instead of steps.secrets.outputs.XYZ
     secrets:

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -16,4 +16,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["ecosystem", "applications"]'
+      teams-array: '["applications-eco"]'


### PR DESCRIPTION
Ensure we get the latest updates by using the main ref for the reusable workflow.