### PR TITLE
fix: only run periodic func on active instance in primary cluster or local mount

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/vault-plugin-secrets-azure/api"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/hashicorp/vault/sdk/helper/locksutil"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -86,77 +87,86 @@ func backend() *azureSecretBackend {
 }
 
 func (b *azureSecretBackend) periodicFunc(ctx context.Context, sys *logical.Request) error {
-	b.Logger().Debug("starting periodic func")
-	if !b.updatePassword {
-		b.Logger().Debug("periodic func", "rotate-root", "no rotate-root update")
-		return nil
-	}
+	// Root rotation through the periodic func writes to storage. Only run this on the
+	// active instance in the primary cluster or local mounts. The periodic func doesn't
+	// run on perf standbys or DR secondaries, but we still protect against this here.
+	replicationState := b.System().ReplicationState()
+	if (b.System().LocalMount() || !replicationState.HasState(consts.ReplicationPerformanceSecondary)) &&
+		!replicationState.HasState(consts.ReplicationDRSecondary) &&
+		!replicationState.HasState(consts.ReplicationPerformanceStandby) {
 
-	config, err := b.getConfig(ctx, sys.Storage)
-	if err != nil {
-		return err
-	}
-
-	// Config can be nil if deleted or when the engine is enabled
-	// but not yet configured.
-	if config == nil {
-		return nil
-	}
-
-	// Password should be at least a minute old before we process it
-	if config.NewClientSecret == "" || (time.Since(config.NewClientSecretCreated) < time.Minute) {
-		return nil
-	}
-
-	b.Logger().Debug("periodic func", "rotate-root", "new password detected, swapping in storage")
-	client, err := b.getClient(ctx, sys.Storage)
-	if err != nil {
-		return err
-	}
-
-	apps, err := client.provider.ListApplications(ctx, fmt.Sprintf("appId eq '%s'", config.ClientID))
-	if err != nil {
-		return err
-	}
-
-	if len(apps) == 0 {
-		return fmt.Errorf("no application found")
-	}
-	if len(apps) > 1 {
-		return fmt.Errorf("multiple applications found - double check your client_id")
-	}
-
-	app := apps[0]
-
-	credsToDelete := []string{}
-	for _, cred := range app.PasswordCredentials {
-		if *cred.KeyID != config.NewClientSecretKeyID {
-			credsToDelete = append(credsToDelete, *cred.KeyID)
+		b.Logger().Debug("starting periodic func")
+		if !b.updatePassword {
+			b.Logger().Debug("periodic func", "rotate-root", "no rotate-root update")
+			return nil
 		}
-	}
 
-	if len(credsToDelete) != 0 {
-		b.Logger().Debug("periodic func", "rotate-root", "removing old passwords from Azure")
-		err = removeApplicationPasswords(ctx, client.provider, *app.ID, credsToDelete...)
+		config, err := b.getConfig(ctx, sys.Storage)
 		if err != nil {
 			return err
 		}
+
+		// Config can be nil if deleted or when the engine is enabled
+		// but not yet configured.
+		if config == nil {
+			return nil
+		}
+
+		// Password should be at least a minute old before we process it
+		if config.NewClientSecret == "" || (time.Since(config.NewClientSecretCreated) < time.Minute) {
+			return nil
+		}
+
+		b.Logger().Debug("periodic func", "rotate-root", "new password detected, swapping in storage")
+		client, err := b.getClient(ctx, sys.Storage)
+		if err != nil {
+			return err
+		}
+
+		apps, err := client.provider.ListApplications(ctx, fmt.Sprintf("appId eq '%s'", config.ClientID))
+		if err != nil {
+			return err
+		}
+
+		if len(apps) == 0 {
+			return fmt.Errorf("no application found")
+		}
+		if len(apps) > 1 {
+			return fmt.Errorf("multiple applications found - double check your client_id")
+		}
+
+		app := apps[0]
+
+		credsToDelete := []string{}
+		for _, cred := range app.PasswordCredentials {
+			if *cred.KeyID != config.NewClientSecretKeyID {
+				credsToDelete = append(credsToDelete, *cred.KeyID)
+			}
+		}
+
+		if len(credsToDelete) != 0 {
+			b.Logger().Debug("periodic func", "rotate-root", "removing old passwords from Azure")
+			err = removeApplicationPasswords(ctx, client.provider, *app.ID, credsToDelete...)
+			if err != nil {
+				return err
+			}
+		}
+
+		b.Logger().Debug("periodic func", "rotate-root", "updating config with new password")
+		config.ClientSecret = config.NewClientSecret
+		config.ClientSecretKeyID = config.NewClientSecretKeyID
+		config.RootPasswordExpirationDate = config.NewClientSecretExpirationDate
+		config.NewClientSecret = ""
+		config.NewClientSecretKeyID = ""
+		config.NewClientSecretCreated = time.Time{}
+
+		err = b.saveConfig(ctx, config, sys.Storage)
+		if err != nil {
+			return err
+		}
+
+		b.updatePassword = false
 	}
-
-	b.Logger().Debug("periodic func", "rotate-root", "updating config with new password")
-	config.ClientSecret = config.NewClientSecret
-	config.ClientSecretKeyID = config.NewClientSecretKeyID
-	config.RootPasswordExpirationDate = config.NewClientSecretExpirationDate
-	config.NewClientSecret = ""
-	config.NewClientSecretKeyID = ""
-	config.NewClientSecretCreated = time.Time{}
-
-	err = b.saveConfig(ctx, config, sys.Storage)
-	if err != nil {
-		return err
-	}
-
-	b.updatePassword = false
 
 	return nil
 }


### PR DESCRIPTION
## Overview

This PR adds a condition to the periodic func that ensures it only runs on the active instance in a primary cluster or on local mounts. This fixes an issue where root credential rotation was taking place on the active/secondary _and_ active/primary. This caused intermittent 401s due to the rotations racing and invalidating the credentials of each other's cached clients.

## Testing

I was able to reproduce this by getting the timing right on the active/secondary's periodicFunc such that it would perform the rotation. This also resulted in a "cannot write to readonly storage" error within the periodic func (see image below).

<img width="1273" alt="Screenshot 2023-07-03 at 5 36 12 PM" src="https://github.com/hashicorp/vault-plugin-secrets-azure/assets/34121980/4e341235-3ce7-4218-8a4d-ac46a3b1b73a">