### PR TITLE
Adds test coverage for service principal group assignment

### DIFF
--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -899,6 +899,7 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 			"AZURE_CLIENT_ID",
 			"AZURE_CLIENT_SECRET",
 			"AZURE_TENANT_ID",
+			"AZURE_GROUP_NAME",
 		)
 
 		b := backend()
@@ -907,6 +908,7 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 		clientID := os.Getenv("AZURE_CLIENT_ID")
 		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 		tenantID := os.Getenv("AZURE_TENANT_ID")
+		groupName := os.Getenv("AZURE_GROUP_NAME")
 
 		config := &logical.BackendConfig{
 			Logger: logging.NewVaultLogger(log.Trace),
@@ -946,6 +948,10 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 				"role_name": "Reader",
 				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
 			}]`, subscriptionID, subscriptionID),
+			"azure_groups": fmt.Sprintf(`[
+			{
+				"group_name": "%s"
+			}]`, groupName),
 		}
 
 		roleResp, err := b.HandleRequest(context.Background(), &logical.Request{


### PR DESCRIPTION
## Overview

This PR adds acceptance test coverage for service principal group assignment. The group is provisioned through the Terraform bootstrap and provided to the test via an environment variable.

Related PR:
- https://github.com/hashicorp/vault/pull/21897

## Testing

```sh
$ make setup-env
$ source ./bootstrap/terraform/local_environment_setup.sh
$ make testacc
==> Checking that code complies with gofmt requirements...
go generate 
VAULT_ACC=1 go test -tags='vault-plugin-secrets-azure' $(go list ./... | grep -v /vendor/)  -timeout 45m
?       github.com/hashicorp/vault-plugin-secrets-azure/api     [no test files]
?       github.com/hashicorp/vault-plugin-secrets-azure/cmd/vault-plugin-secrets-azure  [no test files]
ok      github.com/hashicorp/vault-plugin-secrets-azure 61.648s
```