### PR TITLE
Removes mock from rotate root tests and fixes terraform permissions

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -26,7 +26,7 @@ var (
 	testClientSecret = "testClientSecret"
 )
 
-func getTestBackend(t *testing.T, initConfig bool) (*azureSecretBackend, logical.Storage) {
+func getTestBackendMocked(t *testing.T, initConfig bool) (*azureSecretBackend, logical.Storage) {
 	b := backend()
 
 	config := &logical.BackendConfig{
@@ -60,6 +60,25 @@ func getTestBackend(t *testing.T, initConfig bool) (*azureSecretBackend, logical
 		}
 
 		testConfigCreate(t, b, config.StorageView, cfg)
+	}
+
+	return b, config.StorageView
+}
+
+func getTestBackend(t *testing.T) (*azureSecretBackend, logical.Storage) {
+	b := backend()
+
+	config := &logical.BackendConfig{
+		Logger: logging.NewVaultLogger(log.Trace),
+		System: &logical.StaticSystemView{
+			DefaultLeaseTTLVal: defaultLeaseTTLHr,
+			MaxLeaseTTLVal:     maxLeaseTTLHr,
+		},
+		StorageView: &logical.InmemStorage{},
+	}
+	err := b.Setup(context.Background(), config)
+	if err != nil {
+		t.Fatalf("unable to create backend: %v", err)
 	}
 
 	return b, config.StorageView

--- a/bootstrap/terraform/iam.tf
+++ b/bootstrap/terraform/iam.tf
@@ -12,7 +12,7 @@ data "azuread_application_published_app_ids" "well_known" {}
 data "azuread_client_config" "current" {}
 
 locals {
-  app_rw_owned_by_id = azuread_service_principal.ms_graph.app_role_ids["Application.ReadWrite.OwnedBy"]
+  app_rw_owned_by_id = azuread_service_principal.ms_graph.app_role_ids["Application.ReadWrite.All"]
   group_rw_all_id    = azuread_service_principal.ms_graph.app_role_ids["GroupMember.ReadWrite.All"]
 }
 
@@ -69,7 +69,7 @@ resource "azuread_app_role_assignment" "group_admin_consent" {
 }
 
 resource "azurerm_role_assignment" "vault_sp_read_assignment" {
-  role_definition_name = "Owner"
+  role_definition_name = "User Access Administrator"
   scope                = data.azurerm_subscription.current.id
   principal_id         = azuread_service_principal.vault_azure_sp.object_id
 }
@@ -86,7 +86,7 @@ resource "local_file" "setup_environment_file" {
 export AZURE_TEST_RESOURCE_GROUP=${azurerm_resource_group.vault_azure_rg.name}
 export AZURE_SUBSCRIPTION_ID=${data.azurerm_client_config.current.subscription_id}
 export AZURE_TENANT_ID=${data.azurerm_client_config.current.tenant_id}
-export AZURE_GROUP_NAME=${azuread_group.test-group.display_name}
+export AZURE_GROUP_NAME=${azuread_group.test_group.display_name}
 export AZURE_CLIENT_ID=${azuread_application.vault_azure_app.application_id}
 export AZURE_CLIENT_SECRET=${azuread_service_principal_password.vault_azure_sp_pwd.value}
 EOF
@@ -105,7 +105,7 @@ output "tenant_id" {
 }
 
 output "group_name" {
-  value = azuread_group.test-group.display_name
+  value = azuread_group.test_group.display_name
 }
 
 output "client_id" {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	b, s := getTestBackend(t, false)
+	b, s := getTestBackendMocked(t, false)
 
 	tests := []struct {
 		name     string
@@ -91,7 +91,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigEnvironmentClouds(t *testing.T) {
-	b, s := getTestBackend(t, false)
+	b, s := getTestBackendMocked(t, false)
 
 	config := map[string]interface{}{
 		"subscription_id":   "a228ceec-bf1a-4411-9f95-39678d8cdb34",
@@ -159,7 +159,7 @@ func TestConfigEnvironmentClouds(t *testing.T) {
 }
 
 func TestConfigDelete(t *testing.T) {
-	b, s := getTestBackend(t, false)
+	b, s := getTestBackendMocked(t, false)
 
 	// Test valid config
 	config := map[string]interface{}{

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRoleCreate(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	t.Run("SP role", func(t *testing.T) {
 		spRole1 := map[string]interface{}{
@@ -238,7 +238,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Role TTL Checks", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		const skip = -999
 		tests := []struct {
@@ -281,7 +281,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Role name lookup", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 		var role = map[string]interface{}{
 			"azure_roles": compactJSON(`[
 				{
@@ -319,7 +319,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Group name lookup", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 		var group = map[string]interface{}{
 			"azure_groups": compactJSON(`[
 				{
@@ -355,7 +355,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Duplicate role name and scope", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		var role = map[string]interface{}{
 			"azure_roles": compactJSON(`[
@@ -384,7 +384,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Duplicate role name, different scope", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		var role = map[string]interface{}{
 			"azure_roles": compactJSON(`[
@@ -413,7 +413,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Duplicate group object ID", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		var role = map[string]interface{}{
 			"azure_groups": compactJSON(`[
@@ -442,7 +442,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Role name lookup (multiple match)", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		// if role_name=="multiple", the mock will return multiple IDs, which are not allowed
 		var role = map[string]interface{}{
@@ -474,7 +474,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 
 	t.Run("Group name lookup (multiple match)", func(t *testing.T) {
-		b, s := getTestBackend(t, true)
+		b, s := getTestBackendMocked(t, true)
 
 		// if group_name=="multiple", the mock will return multiple IDs, which are not allowed
 		var role = map[string]interface{}{
@@ -506,7 +506,7 @@ func TestRoleCreate(t *testing.T) {
 }
 
 func TestRoleCreateBad(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// missing roles and Application ID
 	role := map[string]interface{}{}
@@ -542,7 +542,7 @@ func TestRoleCreateBad(t *testing.T) {
 }
 
 func TestRoleUpdateError(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	role := map[string]interface{}{
 		"azure_roles": compactJSON(`[{}]`),
@@ -562,7 +562,7 @@ func TestRoleUpdateError(t *testing.T) {
 }
 
 func TestRoleList(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// Verify empty list
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -618,7 +618,7 @@ func TestRoleList(t *testing.T) {
 }
 
 func TestRoleDelete(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 	name := "test_role"
 	nameAlt := "test_role_alt"
 

--- a/path_rotate_root_test.go
+++ b/path_rotate_root_test.go
@@ -6,6 +6,7 @@ package azuresecrets
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -13,7 +14,20 @@ import (
 )
 
 func TestRotateRootSuccess(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackend(t)
+
+	skipIfMissingEnvVars(t,
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_TENANT_ID",
+	)
+
+	configData := map[string]interface{}{
+		"tenant_id":     os.Getenv("AZURE_TENANT_ID"),
+		"client_id":     os.Getenv("AZURE_CLIENT_ID"),
+		"client_secret": os.Getenv("AZURE_CLIENT_SECRET"),
+	}
+	testConfigCreate(t, b, s, configData)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -21,7 +35,6 @@ func TestRotateRootSuccess(t *testing.T) {
 		Data:      map[string]interface{}{},
 		Storage:   s,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,8 +92,21 @@ func TestRotateRootSuccess(t *testing.T) {
 	}
 }
 
-func TestRotateRootPeroidicFunctionBeforeMinute(t *testing.T) {
-	b, s := getTestBackend(t, true)
+func TestRotateRootPeriodicFunctionBeforeMinute(t *testing.T) {
+	b, s := getTestBackend(t)
+
+	skipIfMissingEnvVars(t,
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_TENANT_ID",
+	)
+
+	configData := map[string]interface{}{
+		"tenant_id":     os.Getenv("AZURE_TENANT_ID"),
+		"client_id":     os.Getenv("AZURE_CLIENT_ID"),
+		"client_secret": os.Getenv("AZURE_CLIENT_SECRET"),
+	}
+	testConfigCreate(t, b, s, configData)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
@@ -88,7 +114,6 @@ func TestRotateRootPeroidicFunctionBeforeMinute(t *testing.T) {
 		Data:      map[string]interface{}{},
 		Storage:   s,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,15 +195,4 @@ func assertStrSliceIsNotEmpty(t *testing.T, strs []string) {
 	if strs == nil || len(strs) == 0 {
 		t.Fatalf("string slice is empty")
 	}
-}
-
-func assertStrSliceIsEmpty(t *testing.T, strs []string) {
-	t.Helper()
-	if strs != nil && len(strs) > 0 {
-		t.Fatalf("string slice is not empty")
-	}
-}
-
-func strPtr(str string) *string {
-	return &str
 }

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -93,7 +93,7 @@ var (
 // fails to have roles associated with it, gets cleaned up by the periodic WAL
 // function.
 func TestSP_WAL_Cleanup(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// overwrite the normal test backend provider with the errMockProvider
 	errMockProvider := newErrMockProvider()
@@ -209,7 +209,7 @@ func assertEmptyWAL(t *testing.T, b *azureSecretBackend, emp api.AzureProvider, 
 }
 
 func TestSPRead(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// verify basic cred issuance
 	t.Run("Basic Role", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestSPRead(t *testing.T) {
 }
 
 func TestStaticSPRead(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// verify basic cred issuance
 	t.Run("Basic", func(t *testing.T) {
@@ -385,7 +385,7 @@ func TestStaticSPRead(t *testing.T) {
 }
 
 func TestPersistentAppSPRead(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	// verify basic cred issuance
 	t.Run("Basic", func(t *testing.T) {
@@ -459,7 +459,7 @@ func TestPersistentAppSPRead(t *testing.T) {
 }
 
 func TestSPRevoke(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	t.Run("roles", func(t *testing.T) {
 		testRoleCreate(t, b, s, "test_role", testRole)
@@ -589,7 +589,7 @@ func TestSPRevoke(t *testing.T) {
 }
 
 func TestStaticSPRevoke(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	testRoleCreate(t, b, s, "test_role", testStaticSPRole)
 
@@ -633,7 +633,7 @@ func TestStaticSPRevoke(t *testing.T) {
 }
 
 func TestSPReadMissingRole(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
@@ -649,7 +649,7 @@ func TestSPReadMissingRole(t *testing.T) {
 }
 
 func TestCredentialReadProviderError(t *testing.T) {
-	b, s := getTestBackend(t, true)
+	b, s := getTestBackendMocked(t, true)
 
 	testRoleCreate(t, b, s, "test_role", testRole)
 
@@ -900,11 +900,13 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 			"AZURE_CLIENT_SECRET",
 			"AZURE_TENANT_ID",
 			"AZURE_GROUP_NAME",
+			"AZURE_TEST_RESOURCE_GROUP",
 		)
 
 		b := backend()
 		s := new(logical.InmemStorage)
 		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroup := os.Getenv("AZURE_TEST_RESOURCE_GROUP")
 		clientID := os.Getenv("AZURE_CLIENT_ID")
 		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 		tenantID := os.Getenv("AZURE_TENANT_ID")
@@ -942,12 +944,12 @@ func TestCredentialInteg_msgraph(t *testing.T) {
 			"azure_roles": fmt.Sprintf(`[
 			{
 				"role_name": "Storage Blob Data Owner",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test1"
+				"scope":  "/subscriptions/%s/resourceGroups/%s"
 			},
 			{
 				"role_name": "Reader",
-				"scope":  "/subscriptions/%s/resourceGroups/vault-azure-secrets-test2"
-			}]`, subscriptionID, subscriptionID),
+				"scope":  "/subscriptions/%s/resourceGroups/%s"
+			}]`, subscriptionID, resourceGroup, subscriptionID, resourceGroup),
 			"azure_groups": fmt.Sprintf(`[
 			{
 				"group_name": "%s"


### PR DESCRIPTION
This PR removes the mocked client from the rotate root tests to give better confidence that future changes don't break anything. This is motivated by a request to find minimally scoped permissions to assign the principal given to Vault. The [prior recommendation](https://github.com/hashicorp/vault/pull/21897) ended up not working for the rotate root API. I didn't realize these tests were mocked because [the exact same tests](https://github.com/hashicorp/vault-plugin-auth-azure/blob/main/path_rotate_root_test.go) in Azure auth are not mocked.

All tests are passing with this update:
```sh
$ make testacc  
==> Checking that code complies with gofmt requirements...
go generate 
VAULT_ACC=1 go test -tags='vault-plugin-secrets-azure' $(go list ./... | grep -v /vendor/)  -timeout 45m
?       github.com/hashicorp/vault-plugin-secrets-azure/api     [no test files]
?       github.com/hashicorp/vault-plugin-secrets-azure/cmd/vault-plugin-secrets-azure  [no test files]
ok      github.com/hashicorp/vault-plugin-secrets-azure 81.315s

```