### PR TITLE
Azure Secrets Engine Customizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.3
 
 IMPROVEMENTS:
+* Add sign_in_audience and tags fields to application registration [GH-174](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/174)
 * Prevent write-ahead-log data from being replicated to performance secondaries [GH-164](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/164)
 * Update dependencies [[GH-161]](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/161)
   * github.com/Azure/azure-sdk-for-go v68.0.0

--- a/api/applications.go
+++ b/api/applications.go
@@ -124,8 +124,12 @@ func (c *MSGraphClient) ListApplications(ctx context.Context, filter string) ([]
 func (c *MSGraphClient) CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (Application, error) {
 	requestBody := models.NewApplication()
 	requestBody.SetDisplayName(&displayName)
-	requestBody.SetSignInAudience(&signInAudience)
 	requestBody.SetTags(tags)
+
+	// only set signInAudience if it's non-empty
+	if signInAudience != "" {
+		requestBody.SetSignInAudience(&signInAudience)
+	}
 
 	resp, err := c.client.Applications().Post(ctx, requestBody, nil)
 	if err != nil {

--- a/api/applications.go
+++ b/api/applications.go
@@ -18,7 +18,7 @@ import (
 
 type ApplicationsClient interface {
 	GetApplication(ctx context.Context, clientID string) (Application, error)
-	CreateApplication(ctx context.Context, displayName string) (Application, error)
+	CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (Application, error)
 	DeleteApplication(ctx context.Context, applicationObjectID string, permanentlyDelete bool) error
 	ListApplications(ctx context.Context, filter string) ([]Application, error)
 	AddApplicationPassword(ctx context.Context, applicationObjectID string, displayName string, endDateTime time.Time) (PasswordCredential, error)
@@ -121,9 +121,11 @@ func (c *MSGraphClient) ListApplications(ctx context.Context, filter string) ([]
 }
 
 // CreateApplication create a new Azure application object.
-func (c *MSGraphClient) CreateApplication(ctx context.Context, displayName string) (Application, error) {
+func (c *MSGraphClient) CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (Application, error) {
 	requestBody := models.NewApplication()
 	requestBody.SetDisplayName(&displayName)
+	requestBody.SetSignInAudience(&signInAudience)
+	requestBody.SetTags(tags)
 
 	resp, err := c.client.Applications().Post(ctx, requestBody, nil)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -56,22 +56,22 @@ func (c *client) Valid() bool {
 // createApp creates a new Azure application.
 // An Application is a needed to create service principals used by
 // the caller for authentication.
-func (c *client) createApp(ctx context.Context) (app api.Application, err error) {
+func (c *client) createApp(ctx context.Context, signInAudience string, tags []string) (app api.Application, err error) {
 	// TODO: Make this name customizable with the same logic as username customization
 	name := uuid.New().String()
 
 	name = appNamePrefix + name
 
-	result, err := c.provider.CreateApplication(ctx, name)
+	result, err := c.provider.CreateApplication(ctx, name, signInAudience, tags)
 
 	return result, err
 }
 
-func (c *client) createAppWithName(ctx context.Context, rolename string) (app api.Application, err error) {
+func (c *client) createAppWithName(ctx context.Context, rolename string, signInAudience string, tags []string) (app api.Application, err error) {
 	intSuffix := fmt.Sprintf("%d", time.Now().Unix())
 	name := fmt.Sprintf("%s%s-%s", appNamePrefix, rolename, intSuffix)
 
-	result, err := c.provider.CreateApplication(ctx, name)
+	result, err := c.provider.CreateApplication(ctx, name, signInAudience, tags)
 
 	return result, err
 }

--- a/path_roles.go
+++ b/path_roles.go
@@ -95,7 +95,7 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 				},
 				"tags": {
 					Type:        framework.TypeCommaStringSlice,
-					Description: "List of Azure tags to attach to an application.",
+					Description: "Azure tags to attach to an application.",
 				},
 				"ttl": {
 					Type:        framework.TypeDurationSecond,

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -197,8 +197,8 @@ func TestRoleCreate(t *testing.T) {
 			"max_ttl":               int64(3000),
 			"azure_roles":           "[]",
 			"azure_groups":          "[]",
-			"sign_in_audience":      "",
-			"tags":                  []string{""},
+			"sign_in_audience":      "PersonalMicrosoftAccount",
+			"tags":                  []string{"environment:production"},
 			"permanently_delete":    false,
 			"persist_app":           false,
 		}
@@ -223,8 +223,8 @@ func TestRoleCreate(t *testing.T) {
 				}]`,
 			),
 			"application_object_id": "",
-			"sign_in_audience":      "",
-			"tags":                  []string{""},
+			"sign_in_audience":      "AzureADandPersonalMicrosoftAccount",
+			"tags":                  []string{"team:engineering", "environment:development", "project:vault_testing"},
 			"azure_groups":          "[]",
 			"persist_app":           false,
 		}
@@ -544,6 +544,22 @@ func TestRoleCreateBad(t *testing.T) {
 	role = map[string]interface{}{"application_object_id": "abc", "azure_roles": "asdf"}
 	resp = testRoleCreateBasic(t, b, s, "test_role_1", role)
 	msg = "error parsing Azure roles"
+	if !strings.Contains(resp.Error().Error(), msg) {
+		t.Fatalf("expected to find: %s, got: %s", msg, resp.Error().Error())
+	}
+
+	// invalid tags
+	role = map[string]interface{}{"tags": []string{"team:engineering", "team:engineering"}}
+	resp = testRoleCreateBasic(t, b, s, "test_role_1", role)
+	msg = "duplicate tags are not allowed"
+	if !strings.Contains(resp.Error().Error(), msg) {
+		t.Fatalf("expected to find: %s, got: %s", msg, resp.Error().Error())
+	}
+
+	// invalid signInAudience
+	role = map[string]interface{}{"sign_in_audience": "asdfg"}
+	resp = testRoleCreateBasic(t, b, s, "test_role_1", role)
+	msg = "Invalid value for sign_in_audience field. Valid values are: AzureADMyOrg, AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, PersonalMicrosoftAccount"
 	if !strings.Contains(resp.Error().Error(), msg) {
 		t.Fatalf("expected to find: %s, got: %s", msg, resp.Error().Error())
 	}

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -44,6 +44,8 @@ func TestRoleCreate(t *testing.T) {
 			"application_object_id": "",
 			"permanently_delete":    true,
 			"persist_app":           false,
+			"sign_in_audience":      "AzureADMyOrg",
+			"tags":                  []string{"project:vault_test"},
 		}
 
 		spRole2 := map[string]interface{}{
@@ -72,6 +74,8 @@ func TestRoleCreate(t *testing.T) {
 			"application_object_id": "",
 			"permanently_delete":    true,
 			"persist_app":           false,
+			"sign_in_audience":      "AzureADMultipleOrgs",
+			"tags":                  []string{"team:engineering", "environment:development"},
 		}
 
 		// Verify basic updates of the name role
@@ -193,6 +197,8 @@ func TestRoleCreate(t *testing.T) {
 			"max_ttl":               int64(3000),
 			"azure_roles":           "[]",
 			"azure_groups":          "[]",
+			"sign_in_audience":      "",
+			"tags":                  []string{""},
 			"permanently_delete":    false,
 			"persist_app":           false,
 		}
@@ -217,6 +223,8 @@ func TestRoleCreate(t *testing.T) {
 				}]`,
 			),
 			"application_object_id": "",
+			"sign_in_audience":      "",
+			"tags":                  []string{""},
 			"azure_groups":          "[]",
 			"persist_app":           false,
 		}

--- a/path_service_principal.go
+++ b/path_service_principal.go
@@ -105,7 +105,7 @@ func (b *azureSecretBackend) createSPSecret(ctx context.Context, s logical.Stora
 	// Create the App, which is the top level object to be tracked in the secret
 	// and deleted upon revocation. If any subsequent step fails, the App will be
 	// deleted as part of WAL rollback.
-	app, err := c.createApp(ctx)
+	app, err := c.createApp(ctx, role.SignInAudience, role.Tags)
 	if err != nil {
 		return nil, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -159,8 +159,8 @@ func getClientOptions(s *clientSettings, httpClient *http.Client) *arm.ClientOpt
 }
 
 // CreateApplication create a new Azure application object.
-func (p *provider) CreateApplication(ctx context.Context, displayName string) (result api.Application, err error) {
-	return p.appClient.CreateApplication(ctx, displayName)
+func (p *provider) CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (result api.Application, err error) {
+	return p.appClient.CreateApplication(ctx, displayName, signInAudience, tags)
 }
 
 func (p *provider) GetApplication(ctx context.Context, applicationObjectID string) (result api.Application, err error) {

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -111,7 +111,7 @@ func (m *mockProvider) CreateServicePrincipal(_ context.Context, _ string, _ tim
 	return id, pass, nil
 }
 
-func (m *mockProvider) CreateApplication(_ context.Context, _ string) (api.Application, error) {
+func (m *mockProvider) CreateApplication(_ context.Context, _ string, _ string, _ []string) (api.Application, error) {
 	if m.ctxTimeout != 0 {
 		// simulate a context deadline error by sleeping for timeout period
 		time.Sleep(m.ctxTimeout)


### PR DESCRIPTION
Adding two configurable fields `sign_in_audience` and `tags` to application registration. 

To test:

```
vault secrets enable azure

vault write azure/config \
    subscription_id=$AZURE_SUBSCRIPTION_ID \
    tenant_id=$AZURE_TENANT_ID \
    client_id=$AZURE_CLIENT_ID \
    client_secret=$AZURE_CLIENT_SECRET

vault write azure/roles/my-role \      
    ttl=1h \
    max_ttl=24h \
    azure_roles=@az_roles.json \
    sign_in_audience=AzureADMyOrg \
    tags="team:engineering","environment:development"

vault read azure/creds/my-role
```

Use the `client_id` to search through all [app registrations in Azure portal](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) to check that the fields are correctly set.