### PR TITLE
Add nil check for response when unassigning roles

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
 		ctxWithResp := policy.WithCaptureResponse(ctx, &rawResponse)
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctxWithResp, id); err != nil {
 			// If a role was deleted manually then Azure returns a error and status 204
-			if rawResponse.StatusCode == http.StatusNoContent || rawResponse.StatusCode == http.StatusNotFound {
+			if rawResponse != nil && rawResponse.StatusCode == http.StatusNoContent || rawResponse.StatusCode == http.StatusNotFound {
 				continue
 			}
 


### PR DESCRIPTION
Adds a missing nil check when unassigning roles which was causing a segmentation fault.

# Fixes
#190 