### PR TITLE
correct msgraph search query - fixes #189

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -73,8 +73,8 @@ func NewMSGraphClient(graphURI string, creds azcore.TokenCredential) (*MSGraphCl
 	return ac, nil
 }
 
-func (c *MSGraphClient) GetApplication(ctx context.Context, clientID string) (Application, error) {
-	filter := fmt.Sprintf("appId eq '%s'", clientID)
+func (c *MSGraphClient) GetApplication(ctx context.Context, applicationObjectID string) (Application, error) {
+	filter := fmt.Sprintf("Id eq '%s'", applicationObjectID)
 	req := applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Filter: &filter,
@@ -91,7 +91,7 @@ func (c *MSGraphClient) GetApplication(ctx context.Context, clientID string) (Ap
 		return Application{}, fmt.Errorf("no application found")
 	}
 	if len(apps) > 1 {
-		return Application{}, fmt.Errorf("multiple applications found - double check your client_id")
+		return Application{}, fmt.Errorf("multiple applications found - double check your Application Object ID")
 	}
 
 	app := apps[0]


### PR DESCRIPTION
# Overview

The refactored validation for static service principals was checking the **application_object_id** by searching for an **application_id**. This updates the search to search for **application_object_id** instead.

# Design of Change
Only the search filter was updated.  
The lookup could possibly be improved by fetching the application object directly rather than searching. But in this case I've opted for the smallest change to resolve the regression.

# Related Issues/Pull Requests
[x] [Issue #189](https://github.com/hashicorp/vault-plugin-secrets-azure/issues/189)


# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
