### PR TITLE
fix(api): get apps by object id

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -73,8 +73,8 @@ func NewMSGraphClient(graphURI string, creds azcore.TokenCredential) (*MSGraphCl
 	return ac, nil
 }
 
-func (c *MSGraphClient) GetApplication(ctx context.Context, clientID string) (Application, error) {
-	filter := fmt.Sprintf("appId eq '%s'", clientID)
+func (c *MSGraphClient) GetApplication(ctx context.Context, objectId string) (Application, error) {
+	filter := fmt.Sprintf("id eq '%s'", objectId)
 	req := applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Filter: &filter,

--- a/api/applications.go
+++ b/api/applications.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ApplicationsClient interface {
-	GetApplication(ctx context.Context, clientID string) (Application, error)
+	GetApplication(ctx context.Context, objectId string) (Application, error)
 	CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (Application, error)
 	DeleteApplication(ctx context.Context, applicationObjectID string, permanentlyDelete bool) error
 	ListApplications(ctx context.Context, filter string) ([]Application, error)


### PR DESCRIPTION
# Overview

Fix an inconsistency between the `GetApplication` function's behavior and that of its callers.

All callers to the function pass in an application's Object ID. However, the function expected the Client ID.

This led to inconsistent behaviors when configuring a role with `application_object_id`:
- You had to pass in the Client ID for the role to be configured successfully in the first place, but...
- Then you couldn't create secrets for that application because the function handling secret creation expects the Object ID.

# Design of Change

Detected this bug while implementing a separate feature. To reproduce, try configuring an Azure role with `application_object_id`. You _shouldn't_ be able to configure the role using the Object ID. If you use the Client ID instead, you can configure the role but then you can't create secrets for that application.

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
