### PR TITLE
feat: explicit max ttl for secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* Adds ability to limit the lifetime of service principal secrets in Azure through `explicit_max_ttl` on roles ([GH-199](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/199))
+
 ## v0.19.0
 
 IMPROVEMENTS:

--- a/backend_test.go
+++ b/backend_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	defaultLeaseTTLHr = 1 * time.Hour
-	maxLeaseTTLHr     = 12 * time.Hour
-	defaultTestTTL    = 300
-	defaultTestMaxTTL = 3600
+	defaultLeaseTTLHr         = 1 * time.Hour
+	maxLeaseTTLHr             = 12 * time.Hour
+	defaultTestTTL            = 300
+	defaultTestMaxTTL         = 3600
+	defaultTestExplicitMaxTTL = 7200
 )
 
 var (
@@ -59,13 +60,14 @@ func getTestBackendMocked(t *testing.T, initConfig bool) (*azureSecretBackend, l
 
 	if initConfig {
 		cfg := map[string]interface{}{
-			"subscription_id": generateUUID(),
-			"tenant_id":       generateUUID(),
-			"client_id":       testClientID,
-			"client_secret":   testClientSecret,
-			"environment":     "AZURECHINACLOUD",
-			"ttl":             defaultTestTTL,
-			"max_ttl":         defaultTestMaxTTL,
+			"subscription_id":  generateUUID(),
+			"tenant_id":        generateUUID(),
+			"client_id":        testClientID,
+			"client_secret":    testClientSecret,
+			"environment":      "AZURECHINACLOUD",
+			"ttl":              defaultTestTTL,
+			"max_ttl":          defaultTestMaxTTL,
+			"explicit_max_ttl": defaultTestExplicitMaxTTL,
 		}
 
 		testConfigCreate(t, b, config.StorageView, cfg, false)

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -315,6 +315,23 @@ func TestSPRead(t *testing.T) {
 
 		equal(t, 20*time.Second, resp.Secret.TTL)
 		equal(t, 30*time.Second, resp.Secret.MaxTTL)
+
+		roleUpdate = map[string]interface{}{
+			"ttl":              20,
+			"explicit_max_ttl": 60,
+		}
+		testRoleCreate(t, b, s, name, roleUpdate)
+
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		equal(t, 20*time.Second, resp.Secret.TTL)
+		equal(t, 60*time.Second, resp.Secret.MaxTTL)
 	})
 }
 
@@ -389,6 +406,23 @@ func TestStaticSPRead(t *testing.T) {
 
 		equal(t, 20*time.Second, resp.Secret.TTL)
 		equal(t, 30*time.Second, resp.Secret.MaxTTL)
+
+		roleUpdate = map[string]interface{}{
+			"ttl":              20,
+			"explicit_max_ttl": 60,
+		}
+		testRoleCreate(t, b, s, name, roleUpdate)
+
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		equal(t, 20*time.Second, resp.Secret.TTL)
+		equal(t, 60*time.Second, resp.Secret.MaxTTL)
 	})
 }
 
@@ -463,6 +497,23 @@ func TestPersistentAppSPRead(t *testing.T) {
 
 		equal(t, 20*time.Second, resp.Secret.TTL)
 		equal(t, 30*time.Second, resp.Secret.MaxTTL)
+
+		roleUpdate = map[string]interface{}{
+			"ttl":              20,
+			"explicit_max_ttl": 60,
+		}
+		testRoleCreate(t, b, s, name, roleUpdate)
+
+		resp, err = b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      "creds/" + name,
+			Storage:   s,
+		})
+
+		assertErrorIsNil(t, err)
+
+		equal(t, 20*time.Second, resp.Secret.TTL)
+		equal(t, 60*time.Second, resp.Secret.MaxTTL)
 	})
 }
 


### PR DESCRIPTION
# Overview

Add `explicit_max_ttl` to Azure role attributes. When set, Application Secrets in Azure AD will be created with a maximum lifetime equal to `explicit_max_ttl`, instead of the hard-coded 10-year default in effect until now.

This enables organizations with compliance requirements to limit secret lifetimes to implement a hard ceiling on the secret's lifetime. This also serves as a backstop against the possibility of Vault failing to revoke the secret when the lease expires.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
- [ ] Fixes #178 
- [ ] Fixes VAULT-12316

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet: [Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [ ] Backwards compatible
