### PR TITLE
Correctly use GetApplication with `ApplicationObjectID` instead of incorrect filter

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ApplicationsClient interface {
-	GetApplication(ctx context.Context, clientID string) (Application, error)
+	GetApplication(ctx context.Context, applicationObjectID string) (Application, error)
 	CreateApplication(ctx context.Context, displayName string, signInAudience string, tags []string) (Application, error)
 	DeleteApplication(ctx context.Context, applicationObjectID string, permanentlyDelete bool) error
 	ListApplications(ctx context.Context, filter string) ([]Application, error)

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -6,11 +6,14 @@ package azuresecrets
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -555,6 +558,89 @@ func TestRoleCreateBad(t *testing.T) {
 	if !strings.Contains(resp.Error().Error(), msg) {
 		t.Fatalf("expected to find: %s, got: %s", msg, resp.Error().Error())
 	}
+}
+
+// TestRolesCreate_applicationObjectID tests that a role
+// cna be created using the Application Object ID field.
+// This test requires valid, sufficiently-privileged
+// Azure credentials in env variables.
+func TestRolesCreate_applicationObjectID(t *testing.T) {
+	if os.Getenv("VAULT_ACC") != "1" {
+		t.SkipNow()
+	}
+
+	if os.Getenv("AZURE_CLIENT_SECRET") == "" {
+		t.Skip("Azure Secrets: Azure environment variables not set. Skipping.")
+	}
+
+	t.Run("service principals", func(t *testing.T) {
+		t.Parallel()
+
+		skipIfMissingEnvVars(t,
+			"AZURE_SUBSCRIPTION_ID",
+			"AZURE_CLIENT_ID",
+			"AZURE_CLIENT_SECRET",
+			"AZURE_TENANT_ID",
+			"AZURE_TEST_RESOURCE_GROUP",
+		)
+
+		b := backend()
+		s := new(logical.InmemStorage)
+		subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		appObjectID := os.Getenv("AZURE_APPLICATION_OBJECT_ID")
+
+		config := &logical.BackendConfig{
+			Logger: logging.NewVaultLogger(log.Trace),
+			System: &logical.StaticSystemView{
+				DefaultLeaseTTLVal: defaultLeaseTTLHr,
+				MaxLeaseTTLVal:     maxLeaseTTLHr,
+			},
+			StorageView: s,
+		}
+		err := b.Setup(context.Background(), config)
+		assertErrorIsNil(t, err)
+
+		configData := map[string]interface{}{
+			"application_object_id": subscriptionID,
+			"client_id":             clientID,
+			"client_secret":         clientSecret,
+			"tenant_id":             tenantID,
+		}
+
+		configResp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      "config",
+			Data:      configData,
+			Storage:   s,
+		})
+		assertRespNoError(t, configResp, err)
+
+		roleName := "test_role_object_id"
+
+		roleData := map[string]interface{}{
+			"application_object_id": appObjectID,
+			"ttl":                   "1h",
+		}
+
+		roleResp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      fmt.Sprintf("roles/%s", roleName),
+			Data:      roleData,
+			Storage:   s,
+		})
+		assertRespNoError(t, roleResp, err)
+
+		credsResp, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      fmt.Sprintf("creds/%s", roleName),
+			Storage:   s,
+		})
+		assertRespNoError(t, credsResp, err)
+
+	})
 }
 
 func TestValidateTags(t *testing.T) {

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -561,7 +561,7 @@ func TestRoleCreateBad(t *testing.T) {
 }
 
 // TestRolesCreate_applicationObjectID tests that a role
-// cna be created using the Application Object ID field.
+// can be created using the Application Object ID field.
 // This test requires valid, sufficiently-privileged
 // Azure credentials in env variables.
 func TestRolesCreate_applicationObjectID(t *testing.T) {

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -135,15 +135,15 @@ func (m *mockProvider) CreateApplication(_ context.Context, _ string, _ string, 
 	}, nil
 }
 
-func (m *mockProvider) GetApplication(_ context.Context, clientID string) (api.Application, error) {
+func (m *mockProvider) GetApplication(_ context.Context, applicationObjectID string) (api.Application, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	appID := m.applications[clientID]
+	appID := m.applications[applicationObjectID]
 
 	return api.Application{
 		AppID:       appID,
-		AppObjectID: clientID,
+		AppObjectID: applicationObjectID,
 	}, nil
 }
 


### PR DESCRIPTION
# Overview
When performing the MSGraph SDK upgrade, the `GetApplication` method was mistranslated. It was expecting a `clientID` to be passed in, and it would then filter off of the client ID in order to fetch the Application. However, the actual usage of `GetApplication` is instead meant to use the `ApplicationObjectID` to query for the application. This can be seen [on this line here](https://github.com/hashicorp/vault-plugin-secrets-azure/blob/main/path_roles.go#L254), where `GetApplication` is only used when the `ApplicationObjectID` is a non-zero value. 

This PR fixes the mistranslation, and correctly fetches the application based on the `ApplicationObjectID` instead of the Client ID.

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
