### PR TITLE
Correct nil check when unassigning roles

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
 		ctxWithResp := policy.WithCaptureResponse(ctx, &rawResponse)
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctxWithResp, id); err != nil {
 			// If a role was deleted manually then Azure returns a error and status 204
-			if rawResponse != nil && rawResponse.StatusCode == http.StatusNoContent || rawResponse.StatusCode == http.StatusNotFound {
+			if rawResponse != nil && (rawResponse.StatusCode == http.StatusNoContent || rawResponse.StatusCode == http.StatusNotFound) {
 				continue
 			}
 


### PR DESCRIPTION
This is a continued fix from hashicorp/vault-plugin-secrets-azure#191 (reported in hashicorp/vault-plugin-secrets-azure#190)

The issue with the original fix is that Go will still try to evaluate the right side of the `||` operation and try to dereference `.StatusCode` of a `nil` `rawResponse`.

Here is a Go playground PoC whipped up by my colleague: https://go.dev/play/p/tu6hOZgv7ZT

# Fixes
hashicorp/vault-plugin-secrets-azure#190
