### PR TITLE
Fix segmentation fault when unassigning role assignments

### DIFF
--- a/client.go
+++ b/client.go
@@ -214,10 +214,10 @@ func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
 	var merr *multierror.Error
 
 	for _, id := range roleIDs {
-		detailedErr := new(azcore.ResponseError)
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctx, id); err != nil {
-			// If a role was deleted manually then Azure returns a error and status 204
-			if errors.As(err, &detailedErr) && (detailedErr.StatusCode == http.StatusNoContent || detailedErr.StatusCode == http.StatusNotFound) {
+			// If a role was deleted manually then Azure returns an error and status 204
+			respErr := new(azcore.ResponseError)
+			if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusNoContent || respErr.StatusCode == http.StatusNotFound) {
 				continue
 			}
 

--- a/client.go
+++ b/client.go
@@ -215,7 +215,7 @@ func (c *client) unassignRoles(ctx context.Context, roleIDs []string) error {
 
 	for _, id := range roleIDs {
 		if _, err := c.provider.DeleteRoleAssignmentByID(ctx, id); err != nil {
-			// If a role was deleted manually then Azure returns an error and status 204
+			// If a role was deleted out-of-band then Azure returns an error and status 204
 			respErr := new(azcore.ResponseError)
 			if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusNoContent || respErr.StatusCode == http.StatusNotFound) {
 				continue

--- a/path_service_principal_test.go
+++ b/path_service_principal_test.go
@@ -888,6 +888,45 @@ func TestRoleAssignmentWALRollback(t *testing.T) {
 	})
 }
 
+// TestUnassignRoleFailures ensures that the plugin can
+// cleanly resolve any errors received when unassigning roles
+func TestUnassignRoleFailures(t *testing.T) {
+	b, s := getTestBackendMocked(t, true)
+
+	mp := newMockProvider()
+	mp.(*mockProvider).failUnassignRoles = true
+	mp.(*mockProvider).expectError = true
+	b.getProvider = func(context.Context, hclog.Logger, logical.SystemView, *clientSettings) (AzureProvider, error) {
+		return mp, nil
+	}
+
+	c, err := b.getClient(context.Background(), s)
+	if err != nil {
+		t.Fatalf("error getting client: %s", err.Error())
+	}
+
+	// verify error is received
+	t.Run("Role unassign fail", func(t *testing.T) {
+		testAssignmentIDs := []string{"test-1", "test-2"}
+		// Remove one of the RA IDs to simulate a failure to assign a role
+		if err := c.unassignRoles(context.Background(), testAssignmentIDs); err == nil {
+			t.Fatalf("expected error but got nil")
+		}
+	})
+
+	mp.(*mockProvider).expectError = false
+
+	// verify the error is properly handled and ignored
+	t.Run("Role unassign error handled", func(t *testing.T) {
+		testAssignmentIDs := []string{"test-1", "test-2"}
+		// Remove one of the RA IDs to simulate a failure to assign a role
+		if err := c.unassignRoles(context.Background(), testAssignmentIDs); err != nil {
+			t.Fatalf("error unassigning Role: %s", err.Error())
+		}
+	})
+
+}
+
 // This is an integration test against the live Azure service. It requires
 // valid, sufficiently-privileged Azure credentials in env variables.
 func TestCredentialInteg_msgraph(t *testing.T) {

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -238,13 +238,13 @@ func (m *mockProvider) DeleteRoleAssignmentByID(_ context.Context, _ string) (ar
 			return armauthorization.RoleAssignmentsClientDeleteByIDResponse{}, &azcore.ResponseError{
 				ErrorCode: "mock: fail to delete role assignment",
 			}
-		} else {
-			// return empty response and with status code; will ignore error and assume role
-			// assignment was manually deleted based on status code
-			return armauthorization.RoleAssignmentsClientDeleteByIDResponse{}, &azcore.ResponseError{
-				StatusCode: m.unassignRolesFailureParams.statusCode,
-				ErrorCode:  "mock: fail to delete role assignment",
-			}
+		}
+
+		// return empty response and with status code; will ignore error and assume role
+		// assignment was manually deleted based on status code
+		return armauthorization.RoleAssignmentsClientDeleteByIDResponse{}, &azcore.ResponseError{
+			StatusCode: m.unassignRolesFailureParams.statusCode,
+			ErrorCode:  "mock: fail to delete role assignment",
 		}
 	}
 	return armauthorization.RoleAssignmentsClientDeleteByIDResponse{}, nil


### PR DESCRIPTION
# Overview
The error handling case in `unassignRoles` was misconstrued, and was causing a panic when unassigning role assignments would fail during a WAL Rollback. This PR appropriately parses the received error from Azure and fixes the if cases to remove the panic case.

A unit test with a mock provider was added to confirm that the plugin can correctly
- return errors when needed
- ignore errors if the status code is 204 or 404 (role assignment was manually deleted)

# Related Issues/Pull Requests
[x] [Issue #190]
[x] [PR #210]

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible

test output without fix:
```
=== RUN   TestUnassignRoleFailures
=== RUN   TestUnassignRoleFailures/Role_unassign_fail
--- FAIL: TestUnassignRoleFailures (0.00s)
    --- FAIL: TestUnassignRoleFailures/Role_unassign_fail (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x3b4b916]
```


test output with fix:
```
=== RUN   TestUnassignRoleFailures
=== RUN   TestUnassignRoleFailures/Role_unassign_fail
=== RUN   TestUnassignRoleFailures/Role_unassign_error_handled
--- PASS: TestUnassignRoleFailures (0.00s)
    --- PASS: TestUnassignRoleFailures/Role_unassign_fail (0.00s)
    --- PASS: TestUnassignRoleFailures/Role_unassign_error_handled (0.00s)
PASS
```