### PR TITLE
handle not found response when deleting app in wal rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## v0.20.1
+### October 14, 2024
+
+IMPROVEMENTS:
+
 * Prevent noisy logs for non-existent or deleted out-of-band errors (https://github.com/hashicorp/vault-plugin-secrets-azure/pull/220)
 
 ## v0.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Prevent noisy logs for non-existent or deleted out-of-band errors (https://github.com/hashicorp/vault-plugin-secrets-azure/pull/220)
+
 ## v0.20.0
 IMPROVEMENTS:
 * Bump Go version to 1.22.6


### PR DESCRIPTION
During the revoke call, Vault prints the below warning in operational logs:

```
secrets.azure.azure_1a4bd492: rollback error deleting App: err="autorest#WithErrorUnlessStatusCode: DELETE https://graph.microsoft.com/v1.0/directory/deletedItems/4ef6b566XXXXXXXXXa-1aa3a778abb7 failed with 404 Not Found: StatusCode=404"
secrets.azure.azure_1a4bd492: rollback error deleting App: err="autorest#WithErrorUnlessStatusCode: DELETE https://graph.microsoft.com/v1.0/directory/deletedItems/68f3cXXXXXXf-9b8c-7af3eef58b06 failed with 404 Not Found: StatusCode=404"
```

Previously, the delete call didn’t return 404 if the app isn’t found. However, we recently switched the underlying API.