### PR TITLE
update sdk and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.0
+	github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555
 	github.com/microsoftgraph/msgraph-sdk-go v1.61.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555
+	github.com/hashicorp/vault/sdk v0.15.1
 	github.com/microsoftgraph/msgraph-sdk-go v1.61.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.1
+	github.com/hashicorp/vault/sdk v0.15.2
 	github.com/microsoftgraph/msgraph-sdk-go v1.61.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mitchellh/mapstructure v1.5.0
@@ -108,6 +108,6 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/grpc v1.69.4 // indirect
-	google.golang.org/protobuf v1.36.3 // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.1 h1:Y8CkijkR2UfFfVLO4J58JP4A4NAaxvafyjlZvzt0hu4=
-github.com/hashicorp/vault/sdk v0.15.1/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.2 h1:Rp5Yp4lyBhlWgq24ZVb2n/YN47RKOAvmx/jlMfS9ku4=
+github.com/hashicorp/vault/sdk v0.15.2/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -375,8 +375,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576/go.mod h1:5uTbfoYQed2U9p3KIj2/Zzm02PYhndfdmML0qC3q3FU=
 google.golang.org/grpc v1.69.4 h1:MF5TftSMkd8GLw/m0KM6V8CMOCY6NZ1NQDPGFgbTt4A=
 google.golang.org/grpc v1.69.4/go.mod h1:vyjdE6jLBI76dgpDojsFGNaHlxdjXN9ghpnd2o7JGZ4=
-google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
-google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.0 h1:xNo1lL2shm0yE4coXNZkTV/6++2GfEh+/cCAfBjzEnA=
-github.com/hashicorp/vault/sdk v0.15.0/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555 h1:5VS5U0Ps4vQaCCJCp/o1LMnmEn/TF6rZnCm+9Hnl1dE=
+github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555 h1:5VS5U0Ps4vQaCCJCp/o1LMnmEn/TF6rZnCm+9Hnl1dE=
-github.com/hashicorp/vault/sdk v0.15.1-0.20250221185133-d0618a6ce555/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.1 h1:Y8CkijkR2UfFfVLO4J58JP4A4NAaxvafyjlZvzt0hu4=
+github.com/hashicorp/vault/sdk v0.15.1/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/path_config.go
+++ b/path_config.go
@@ -204,7 +204,7 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 	// set up rotation after everything is fine
 	var rotOp string
 	if config.ShouldDeregisterRotationJob() {
-		rotOp = "deregistration"
+		rotOp = rotation.PerformedDeregistration
 		// Ensure de-registering only occurs on updates and if
 		// a credential has actually been registered (rotation_period or rotation_schedule is set)
 		deregisterReq := &rotation.RotationJobDeregisterRequest{
@@ -218,7 +218,7 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 		}
 
 	} else if config.ShouldRegisterRotationJob() {
-		rotOp = "registeration"
+		rotOp = rotation.PerformedRegistration
 		req := &rotation.RotationJobConfigureRequest{
 			MountPoint:       req.MountPoint,
 			ReqPath:          req.Path,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -35,8 +35,8 @@ func TestConfig(t *testing.T) {
 				"root_password_ttl":          15768000,
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -58,8 +58,8 @@ func TestConfig(t *testing.T) {
 				"root_password_ttl":          60,
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -81,8 +81,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "AZURECHINACLOUD",
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -105,8 +105,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "AZURECHINACLOUD",
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -128,8 +128,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "",
 				"identity_token_ttl":         int64(500),
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -244,7 +244,7 @@ func TestConfigDelete(t *testing.T) {
 		"root_password_ttl":          int((24 * time.Hour).Seconds()),
 		"identity_token_audience":    "",
 		"identity_token_ttl":         int64(0),
-		"rotation_window":            0,
+		"rotation_window":            "1h",
 		"rotation_schedule":          "",
 		"disable_automated_rotation": false,
 	}
@@ -252,7 +252,8 @@ func TestConfigDelete(t *testing.T) {
 	testConfigCreate(t, b, s, config, false)
 
 	delete(config, "client_secret")
-	config["rotation_period"] = 0
+	config["rotation_period"] = float64(0)
+	config["rotation_window"] = time.Hour.Seconds()
 	testConfigRead(t, b, s, config)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -275,9 +276,9 @@ func TestConfigDelete(t *testing.T) {
 		"root_password_ttl":          0,
 		"identity_token_audience":    "",
 		"identity_token_ttl":         int64(0),
-		"rotation_window":            0,
+		"rotation_window":            float64(0),
 		"rotation_schedule":          "",
-		"rotation_period":            0,
+		"rotation_period":            float64(0),
 		"disable_automated_rotation": false,
 	}
 	testConfigRead(t, b, s, config)


### PR DESCRIPTION
This PR updates the tests to work with the new expanded values for rotation period and rotation window (now durations)

I'm doing this in advance of the new SDK being tagged for time-efficiency reasons, but before this PR is merged, it will have to be pinned to the new (presumably 0.15.1) of the vault SDK.