### PR TITLE
Revert role name change so that it's no longer a GUID

### DIFF
--- a/path_roles.go
+++ b/path_roles.go
@@ -338,7 +338,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			roleDef = *defs[0]
 		}
 		roleDefID := *roleDef.ID
-		roleDefName := *roleDef.Name
+		roleDefName := *roleDef.Properties.RoleName
 
 		r.RoleName, r.RoleID = roleDefName, roleDefID
 

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -100,9 +100,11 @@ func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (
 	roleName := s[1]
 	return armauthorization.RoleDefinitionsClientGetByIDResponse{
 		RoleDefinition: armauthorization.RoleDefinition{
-			Properties: &armauthorization.RoleDefinitionProperties{},
-			ID:         &roleID,
-			Name:       &roleName,
+			Properties: &armauthorization.RoleDefinitionProperties{
+				RoleName: &roleName,
+			},
+			ID:   &roleID,
+			Name: &roleName,
 		},
 	}, nil
 }


### PR DESCRIPTION
# Overview

**What is the change?** 
Recent versions of Vault, have the azure secrets engine roles keep the Azure role name (role_name) as GUID and not as friendly name. The last known version where this was working as expected 1.15.5. This PR reverts back to the old behavior.

**Who the change affects or is for (stakeholders)?**
Wells Fargo (one of our customers) requested that this change be made. The customer was not satisfied with the initial workaround and gave the following response: "As humans it’s hard to deal in GUIDs especially when we have IAM teams doing approvals and having to do some sort of translation between a role name and a GUID."

# Local Testing
1. Created Azure Subscription with Owner-level priveleges 
2. Installed Vault 1.16.x and tested on the releases/vault.1.16.x branch
3. Cloned vault-plugin-secrets-azure and made modifications necessary
4. Built local plugin with `make dev` and moved binary into local plugin folder

5.  Started Vault Server
`vault server -dev -dev-root-token-id=root -dev-plugin-dir=$HOME/Desktop/vault-plugins -log-level=debug`

6. Opened another terminal and ran the following commands to create an Azure role

```
export VAULT_SKIP_VERIFY=true
export VAULT_ADDR="http://127.0.0.1:8200"
export SHASUM=$(shasum -a 256 $HOME/Desktop/vault-plugins/vault-plugin-secrets-azure | cut -d ' ' -f1)
vault plugin register -sha256=$SHASUM secret vault-plugin-secrets-azure
vault secrets enable -path=azure-custom vault-plugin-secrets-azure


vault write azure-custom/config \
    subscription_id=$AZURE_SUBSCRIPTION_ID \
    tenant_id=$AZURE_TENANT_ID \
    client_id=$AZURE_CLIENT_ID \
    client_secret=$AZURE_CLIENT_SECRET
    
vault write azure-custom/roles/my-role \
    azure_roles=-<<EOF
      [
        {
          "role_name": "Contributor",
          "scope": "/subscriptions/d55606dc-3846-4864-9c44-389ec37720c9/resourceGroups/testResourceGroup"
        }
      ]
EOF
```

7. Verified that change worked by logging the values of the role name before and after the change. Can see the role name before the change was a GUID and after was the actual name of the role.

Before:
```
2025-03-09T23:00:52.181-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_54e61400.vault-plugin-secrets-azure.vault-plugin-secrets-azure: ============== Role Update Triggered ==============: timestamp=2025-03-09T23:00:52.181-0700
2025-03-09T23:00:53.231-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_54e61400.vault-plugin-secrets-azure.vault-plugin-secrets-azure: Role ID: : EXTRA_VALUE_AT_END=/subscriptions/d55606dc-3846-4864-9c44-389ec37720c9/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c timestamp=2025-03-09T23:00:53.230-0700
2025-03-09T23:00:53.231-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_54e61400.vault-plugin-secrets-azure.vault-plugin-secrets-azure: Role Name: : EXTRA_VALUE_AT_END=b24988ac-6180-42a0-ab88-20f7382dd24c timestamp=2025-03-09T23:00:53.230-0700
```


After:
```
2025-03-09T22:47:32.859-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_c8e5d1fc.vault-plugin-secrets-azure.vault-plugin-secrets-azure: ================= ROLE UPDATE TRIGGERED =================: timestamp=2025-03-09T22:47:32.859-0700
2025-03-09T22:47:32.860-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_c8e5d1fc.vault-plugin-secrets-azure.vault-plugin-secrets-azure: roleDefID: : EXTRA_VALUE_AT_END=/subscriptions/d55606dc-3846-4864-9c44-389ec37720c9/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c timestamp=2025-03-09T22:47:32.859-0700
2025-03-09T22:47:32.860-0700 [INFO]  secrets.vault-plugin-secrets-azure.vault-plugin-secrets-azure_c8e5d1fc.vault-plugin-secrets-azure.vault-plugin-secrets-azure: roleDefName: : EXTRA_VALUE_AT_END=Contributor timestamp=2025-03-09T22:47:32.859-0700
```


# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
