### PR TITLE
Backport change from #233 into version 1.18.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.21.1
+### February 26, 2025
+
+IMPROVEMENTS:
+* Updated dependencies:
+  * `github.com/hashicorp/vault/sdk` v0.15.0 -> v0.15.2
+  * `golang.org/x/crypto` v0.33.0 -> v0.35.0
+  * `github.com/jose/go-jose` v4.0.4 -> v4.0.5
+
 ## v0.21.0
 ### February 13, 2025
 

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/vault/api v1.16.0
-	github.com/hashicorp/vault/sdk v0.15.0
+	github.com/hashicorp/vault/sdk v0.15.2
 	github.com/microsoftgraph/msgraph-sdk-go v1.61.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mitchellh/mapstructure v1.5.0
@@ -108,6 +108,6 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/grpc v1.69.4 // indirect
-	google.golang.org/protobuf v1.36.3 // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
-github.com/hashicorp/vault/sdk v0.15.0 h1:xNo1lL2shm0yE4coXNZkTV/6++2GfEh+/cCAfBjzEnA=
-github.com/hashicorp/vault/sdk v0.15.0/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
+github.com/hashicorp/vault/sdk v0.15.2 h1:Rp5Yp4lyBhlWgq24ZVb2n/YN47RKOAvmx/jlMfS9ku4=
+github.com/hashicorp/vault/sdk v0.15.2/go.mod h1:2Wj2tHIgfz0gNWgEPWBbCXFIiPrq96E8FTjPNV9J1Bc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -375,8 +375,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576/go.mod h1:5uTbfoYQed2U9p3KIj2/Zzm02PYhndfdmML0qC3q3FU=
 google.golang.org/grpc v1.69.4 h1:MF5TftSMkd8GLw/m0KM6V8CMOCY6NZ1NQDPGFgbTt4A=
 google.golang.org/grpc v1.69.4/go.mod h1:vyjdE6jLBI76dgpDojsFGNaHlxdjXN9ghpnd2o7JGZ4=
-google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
-google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
+golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
-github.com/go-jose/go-jose/v4 v4.0.4 h1:VsjPI33J0SB9vQM6PLmNjoHqMQNGPiZ0rHL7Ni7Q6/E=
-github.com/go-jose/go-jose/v4 v4.0.4/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/path_config.go
+++ b/path_config.go
@@ -204,7 +204,7 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 	// set up rotation after everything is fine
 	var rotOp string
 	if config.ShouldDeregisterRotationJob() {
-		rotOp = "deregistration"
+		rotOp = rotation.PerformedDeregistration
 		// Ensure de-registering only occurs on updates and if
 		// a credential has actually been registered (rotation_period or rotation_schedule is set)
 		deregisterReq := &rotation.RotationJobDeregisterRequest{
@@ -218,7 +218,7 @@ func (b *azureSecretBackend) pathConfigWrite(ctx context.Context, req *logical.R
 		}
 
 	} else if config.ShouldRegisterRotationJob() {
-		rotOp = "registeration"
+		rotOp = rotation.PerformedRegistration
 		req := &rotation.RotationJobConfigureRequest{
 			MountPoint:       req.MountPoint,
 			ReqPath:          req.Path,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -35,8 +35,8 @@ func TestConfig(t *testing.T) {
 				"root_password_ttl":          15768000,
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -58,8 +58,8 @@ func TestConfig(t *testing.T) {
 				"root_password_ttl":          60,
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -81,8 +81,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "AZURECHINACLOUD",
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -105,8 +105,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "AZURECHINACLOUD",
 				"identity_token_ttl":         int64(0),
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -128,8 +128,8 @@ func TestConfig(t *testing.T) {
 				"environment":                "",
 				"identity_token_ttl":         int64(500),
 				"identity_token_audience":    "vault-azure-secrets-d0f0d253",
-				"rotation_window":            0,
-				"rotation_period":            0,
+				"rotation_window":            float64(0),
+				"rotation_period":            float64(0),
 				"rotation_schedule":          "",
 				"disable_automated_rotation": false,
 			},
@@ -244,7 +244,7 @@ func TestConfigDelete(t *testing.T) {
 		"root_password_ttl":          int((24 * time.Hour).Seconds()),
 		"identity_token_audience":    "",
 		"identity_token_ttl":         int64(0),
-		"rotation_window":            0,
+		"rotation_window":            "1h",
 		"rotation_schedule":          "",
 		"disable_automated_rotation": false,
 	}
@@ -252,7 +252,8 @@ func TestConfigDelete(t *testing.T) {
 	testConfigCreate(t, b, s, config, false)
 
 	delete(config, "client_secret")
-	config["rotation_period"] = 0
+	config["rotation_period"] = float64(0)
+	config["rotation_window"] = time.Hour.Seconds()
 	testConfigRead(t, b, s, config)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
@@ -275,9 +276,9 @@ func TestConfigDelete(t *testing.T) {
 		"root_password_ttl":          0,
 		"identity_token_audience":    "",
 		"identity_token_ttl":         int64(0),
-		"rotation_window":            0,
+		"rotation_window":            float64(0),
 		"rotation_schedule":          "",
-		"rotation_period":            0,
+		"rotation_period":            float64(0),
 		"disable_automated_rotation": false,
 	}
 	testConfigRead(t, b, s, config)

--- a/path_roles.go
+++ b/path_roles.go
@@ -338,7 +338,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			roleDef = *defs[0]
 		}
 		roleDefID := *roleDef.ID
-		roleDefName := *roleDef.Name
+		roleDefName := *roleDef.Properties.RoleName
 
 		r.RoleName, r.RoleID = roleDefName, roleDefID
 

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -100,9 +100,11 @@ func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (
 	roleName := s[1]
 	return armauthorization.RoleDefinitionsClientGetByIDResponse{
 		RoleDefinition: armauthorization.RoleDefinition{
-			Properties: &armauthorization.RoleDefinitionProperties{},
-			ID:         &roleID,
-			Name:       &roleName,
+			Properties: &armauthorization.RoleDefinitionProperties{
+				RoleName: &roleName,
+			},
+			ID:   &roleID,
+			Name: &roleName,
 		},
 	}, nil
 }


### PR DESCRIPTION
# Overview
Backport [233](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/233) into plugin for vault 1.16.x.

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
