### PR TITLE
Backport change from #233 into version 1.18.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.21.2
+### March 24, 2025
+
+BUG FIXES:
+* Revert role name from GUID back to human readable format [[GH-233]](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/233)
+
 ## v0.21.1
 ### February 26, 2025
 

--- a/path_roles.go
+++ b/path_roles.go
@@ -338,7 +338,7 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			roleDef = *defs[0]
 		}
 		roleDefID := *roleDef.ID
-		roleDefName := *roleDef.Name
+		roleDefName := *roleDef.Properties.RoleName
 
 		r.RoleName, r.RoleID = roleDefName, roleDefID
 

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -100,7 +100,9 @@ func (m *mockProvider) GetRoleDefinitionByID(_ context.Context, roleID string) (
 	roleName := s[1]
 	return armauthorization.RoleDefinitionsClientGetByIDResponse{
 		RoleDefinition: armauthorization.RoleDefinition{
-			Properties: &armauthorization.RoleDefinitionProperties{},
+			Properties: &armauthorization.RoleDefinitionProperties{
+				RoleName: &roleName,
+			},
 			ID:         &roleID,
 			Name:       &roleName,
 		},


### PR DESCRIPTION
# Overview
Backport [233](https://github.com/hashicorp/vault-plugin-secrets-azure/pull/233) into plugin for vault 1.16.x.


# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
