### PR TITLE
Forward Performance Secondary Requests when configuring root credentials

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -98,12 +98,16 @@ func pathConfig(b *azureSecretBackend) *framework.Path {
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathConfigWrite,
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathConfigDelete,


### PR DESCRIPTION
Fixes a bug where Performance Secondaries panic when they attempt to de-register / register jobs to the RM, since the RM is nil on Perf Secondaries. This fix appropriately forwards such requests to the Primary node in the cluster.