### PR TITLE
Generate Static Role Credentials

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -68,6 +68,7 @@ func backend() *azureSecretBackend {
 				pathConfig(&b),
 				pathServicePrincipal(&b),
 				pathRotateRoot(&b),
+				pathStaticRoleCred(&b),
 			},
 		),
 		Secrets: []*framework.Secret{

--- a/backend.go
+++ b/backend.go
@@ -64,11 +64,11 @@ func backend() *azureSecretBackend {
 		Paths: framework.PathAppend(
 			pathsRole(&b),
 			pathStaticRoles(&b),
+			pathStaticRoleCreds(&b),
 			[]*framework.Path{
 				pathConfig(&b),
 				pathServicePrincipal(&b),
 				pathRotateRoot(&b),
-				pathStaticRoleCred(&b),
 			},
 		),
 		Secrets: []*framework.Secret{

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -1,0 +1,142 @@
+package azuresecrets
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	pathStaticCred = "static-cred/"
+)
+
+type azureStaticCred struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+func pathStaticRoleCred(b *azureSecretBackend) *framework.Path {
+	fields := map[string]*framework.FieldSchema{
+		paramRoleName: {
+			Type:        framework.TypeLowerCaseString,
+			Description: "Name of the static role. Must be a lowercase string.",
+			Required:    true,
+		},
+	}
+
+	return &framework.Path{
+		Pattern: pathStaticCred + framework.GenericNameRegex("name"),
+		Fields:  fields,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathStaticCredRotate,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathStaticCredRead,
+			},
+		},
+		HelpSynopsis:    pathStaticCredHelpSyn,
+		HelpDescription: pathStaticCredHelpDesc,
+	}
+}
+
+func (b *azureSecretBackend) pathStaticCredRotate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	name := data.Get(paramRoleName).(string)
+
+	role, err := getStaticRole(ctx, req.Storage, name)
+	if err != nil {
+		return nil, fmt.Errorf("error reading role from storage: %w", err)
+	}
+	if role == nil {
+		//if req.Operation == logical.UpdateOperation {
+		//	return nil, fmt.Errorf("role entry not found during update operation")
+		//}
+		//
+		//role = &azureStaticRole{}
+	}
+
+	return nil, nil
+}
+
+func (b *azureSecretBackend) createAzureStaticCred(ctx context.Context, s logical.Storage, applicationObjId string, name string) error {
+	client, err := b.getClient(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	app, err := client.provider.GetApplication(ctx, applicationObjId)
+	if err != nil {
+		return fmt.Errorf("error loading Application: %w", err)
+	}
+
+	spID, password, _, err := client.createSP(ctx, app, spExpiration)
+	if err != nil {
+		return err
+	}
+
+	cred := &azureStaticCred{
+		ClientID:     spID,
+		ClientSecret: password,
+	}
+
+	err = saveStaticCred(ctx, s, cred, name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *azureSecretBackend) pathStaticCredRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	name := data.Get(paramRoleName).(string)
+
+	cred, err := getStaticCred(ctx, req.Storage, name)
+	if err != nil {
+		return nil, fmt.Errorf("error reading role: %w", err)
+	}
+	if cred == nil {
+		return nil, nil
+	}
+
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"client_id":     cred.ClientID,
+			"client_secret": cred.ClientSecret,
+		},
+	}
+
+	return resp, nil
+}
+
+func saveStaticCred(ctx context.Context, s logical.Storage, cred *azureStaticCred, name string) error {
+	entry, err := logical.StorageEntryJSON(pathStaticCred+name, cred)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, entry)
+}
+
+func getStaticCred(ctx context.Context, s logical.Storage, name string) (*azureStaticCred, error) {
+	entry, err := s.Get(ctx, pathStaticCred+name)
+	if err != nil || entry == nil {
+		return nil, err
+	}
+
+	var cred azureStaticCred
+	if err := entry.DecodeJSON(&cred); err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
+const (
+	pathStaticCredHelpSyn = `
+Manage the credentials for an Azure static role.
+`
+	pathStaticCredHelpDesc = `
+This path lets you manage the credentials of static roles for the Azure secret backend.
+`
+)

--- a/path_static_creds.go
+++ b/path_static_creds.go
@@ -49,11 +49,13 @@ func (b *azureSecretBackend) pathStaticCredRotate(ctx context.Context, req *logi
 		return nil, fmt.Errorf("error reading role from storage: %w", err)
 	}
 	if role == nil {
-		//if req.Operation == logical.UpdateOperation {
-		//	return nil, fmt.Errorf("role entry not found during update operation")
-		//}
-		//
-		//role = &azureStaticRole{}
+		return nil, fmt.Errorf("role not found in storage")
+	}
+
+	// create and save new azure static credential
+	err = b.createAzureStaticCred(ctx, req.Storage, role.ApplicationObjectID, name)
+	if err != nil {
+		return nil, fmt.Errorf("error rotating static cred: %w", err)
 	}
 
 	return nil, nil

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -1,0 +1,44 @@
+package azuresecrets
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/logical"
+	"testing"
+)
+
+// create role and confirm that it's client id and client secret are not nil
+// and matches the expected output
+
+func TestStaticCred_Read(t *testing.T) {
+	b, s := getTestBackendMocked(t, true)
+
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      pathStaticRole + roleName,
+		Data: map[string]interface{}{
+			paramApplicationObjectID: appObjID,
+		},
+		Storage: s,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      pathStaticCred + roleName,
+		Storage:   s,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+
+	fmt.Println("resp", resp)
+}

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -2,8 +2,10 @@ package azuresecrets
 
 import (
 	"context"
-	"github.com/hashicorp/vault/sdk/logical"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
 )
 
 // create role and confirm that it's client id and client secret are not nil
@@ -33,4 +35,58 @@ func TestStaticCred_Read(t *testing.T) {
 	// ensure that the client id and secret have been retrieved
 	assertNotEmptyString(t, resp.Data["client_id"].(string))
 	assertNotEmptyString(t, resp.Data["client_secret"].(string))
+}
+
+func TestStaticCred_Rotate(t *testing.T) {
+	b, s := getTestBackendMocked(t, true)
+
+	// create a static role, which in turn creates the Azure credential
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      pathStaticRole + roleName,
+		Data: map[string]interface{}{
+			paramApplicationObjectID: appObjID,
+		},
+		Storage: s,
+	})
+	assertRespNoError(t, resp, err)
+
+	// read the Azure credential to ensure that it was properly created
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      pathStaticCred + roleName,
+		Storage:   s,
+	})
+	assertRespNoError(t, resp, err)
+
+	originalClientID := resp.Data["client_id"].(string)
+	originalClientSecret := resp.Data["client_secret"].(string)
+
+	// ensure that the client id and secret have been retrieved
+	assertNotEmptyString(t, originalClientID)
+	assertNotEmptyString(t, originalClientSecret)
+
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      pathStaticCred + roleName,
+		Storage:   s,
+	})
+
+	assertRespNoError(t, resp, err)
+	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      pathStaticCred + roleName,
+		Storage:   s,
+	})
+
+	newClientID := resp.Data["client_id"].(string)
+	newClientSecret := resp.Data["client_secret"].(string)
+
+	assertRespNoError(t, resp, err)
+	assertNotEmptyString(t, newClientID)
+	assertNotEmptyString(t, newClientSecret)
+
+	// ensure that the original client id/secret is different from the new one
+	assert.NotEqual(t, originalClientID, newClientID)
+	assert.NotEqual(t, originalClientSecret, newClientSecret)
 }

--- a/path_static_creds_test.go
+++ b/path_static_creds_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// create role and confirm that it's client id and client secret are not nil
-// and matches the expected output
+// create role and confirm that the credentials associated with the role match
+// the expected output
 func TestStaticCred_Read(t *testing.T) {
 	b, s := getTestBackendMocked(t, true)
 
@@ -27,14 +27,16 @@ func TestStaticCred_Read(t *testing.T) {
 	// read the Azure credential to ensure that it was properly created
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      pathStaticCred + roleName,
+		Path:      pathStaticCreds + roleName,
 		Storage:   s,
 	})
 	assertRespNoError(t, resp, err)
 
 	// ensure that the client id and secret have been retrieved
 	assertNotEmptyString(t, resp.Data["client_id"].(string))
+	assertNotEmptyString(t, resp.Data["secret_id"].(string))
 	assertNotEmptyString(t, resp.Data["client_secret"].(string))
+	assertNotEmptyString(t, resp.Data["expiration"].(string))
 }
 
 func TestStaticCred_Rotate(t *testing.T) {
@@ -54,7 +56,7 @@ func TestStaticCred_Rotate(t *testing.T) {
 	// read the Azure credential to ensure that it was properly created
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      pathStaticCred + roleName,
+		Path:      pathStaticCreds + roleName,
 		Storage:   s,
 	})
 	assertRespNoError(t, resp, err)
@@ -68,14 +70,14 @@ func TestStaticCred_Rotate(t *testing.T) {
 
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      pathStaticCred + roleName,
+		Path:      pathStaticCreds + roleName,
 		Storage:   s,
 	})
 
 	assertRespNoError(t, resp, err)
 	resp, err = b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
-		Path:      pathStaticCred + roleName,
+		Path:      pathStaticCreds + roleName,
 		Storage:   s,
 	})
 

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -116,15 +116,9 @@ func (b *azureSecretBackend) pathStaticRoleCreateUpdate(ctx context.Context, req
 		return logical.ErrorResponse("missing required field 'application_object_id'"), nil
 	}
 
-	client, err := b.getClient(ctx, req.Storage)
+	err = b.createAzureStaticCred(ctx, req.Storage, name, role.ApplicationObjectID)
 	if err != nil {
 		return nil, err
-	}
-
-	// checks if the application object id is valid
-	_, err = client.provider.GetApplication(ctx, role.ApplicationObjectID)
-	if err != nil {
-		return nil, fmt.Errorf("error loading Application: %w", err)
 	}
 
 	// save the role in storage

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -116,7 +116,7 @@ func (b *azureSecretBackend) pathStaticRoleCreateUpdate(ctx context.Context, req
 		return logical.ErrorResponse("missing required field 'application_object_id'"), nil
 	}
 
-	err = b.createAzureStaticCred(ctx, req.Storage, name, role.ApplicationObjectID)
+	err = b.createAzureStaticCred(ctx, req.Storage, role.ApplicationObjectID, name)
 	if err != nil {
 		return nil, err
 	}

--- a/path_static_roles.go
+++ b/path_static_roles.go
@@ -49,10 +49,14 @@ func pathStaticRoles(b *azureSecretBackend) []*framework.Path {
 			Fields:  fields,
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.CreateOperation: &framework.PathOperation{
-					Callback: b.pathStaticRoleCreateUpdate,
+					Callback:                    b.pathStaticRoleCreateUpdate,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.pathStaticRoleCreateUpdate,
+					Callback:                    b.pathStaticRoleCreateUpdate,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
 				},
 				logical.DeleteOperation: &framework.PathOperation{
 					Callback: b.pathStaticRoleDelete,

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -181,7 +181,7 @@ func (m *mockProvider) DeleteServicePrincipal(_ context.Context, spObjectID stri
 	return nil
 }
 
-func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, _ string, _ time.Time) (result api.PasswordCredential, err error) {
+func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, _ string, endDateTime time.Time) (result api.PasswordCredential, err error) {
 	keyID := uuid.New().String()
 	pass := uuid.New().String()
 
@@ -192,6 +192,7 @@ func (m *mockProvider) AddApplicationPassword(_ context.Context, _ string, _ str
 	return api.PasswordCredential{
 		KeyID:      keyID,
 		SecretText: pass,
+		EndDate:    endDateTime,
 	}, nil
 }
 


### PR DESCRIPTION
# Overview

This PR adds the following

* Creates an Azure credential upon role creation and stores it.
* Includes a `static-creds/:role_name` endpoint, which allows the user to read the latest provisioned credentials by Vault.
* Includes a `rotate-role/:role_name` endpoint, which allows the user to rotate the Azure credential through a manual process
* Relevant unit tests to ensure that existing credentials can be read and rotated, and rotation attempts on non-existing roles through an error.

# Manual Testing

## Confirmation that the role's credentials can be generated & read

```
vault write azure/static-roles/my-static-role \
        application_object_id=$AZURE_APP_OBJECT_ID \
        ttl="2592000"

vault read azure/static-roles/my-static-role
Key                      Value
---                      -----
application_object_id    my_application_object_id

vault read azure/static-creds/my-static-role
Key              Value
---              -----
client_id           my_client_id
client_secret   my_client_secret
expiration        2025-09-19T06:02:29Z
secret_id         my_secret_id
```

### Confirmation From Azure Portal
<img width="574" height="45" alt="Screenshot 2025-08-20 at 11 09 47 PM" src="https://github.com/user-attachments/assets/18721ab2-0e14-4017-8567-a1ea909c7faf" />


### Confirmation that the role's credentials can be rotated

```
vault write azure/rotate-role/my-static-role ttl=2592000
Success! Data written to: azure/rotate-role/my-static-role

vault read azure/static-creds/my-static-role
Key              Value
---              -----
client_id            my_client_id
client_secret    different_client_secret
expiration         2025-09-20T06:05:12Z
secret_id          different_secret_id
```

### Confirmation From Azure Portal that the credential is different
<img width="505" height="40" alt="Screenshot 2025-08-20 at 11 10 33 PM" src="https://github.com/user-attachments/assets/150447e8-956c-41df-bc24-fa659adb3f45" />
