### PR TITLE
Backport: update retry logic and error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
@@ -80,8 +81,8 @@ func (c *client) createAppWithName(ctx context.Context, rolename string, signInA
 func (c *client) createSP(
 	ctx context.Context,
 	app api.Application,
-	duration time.Duration) (spID string, password string, endDate time.Time, err error) {
-
+	duration time.Duration,
+) (spID string, password string, endDate time.Time, err error) {
 	type idPass struct {
 		ID       string
 		Password string
@@ -92,21 +93,21 @@ func (c *client) createSP(
 		now := time.Now()
 		endDate := now.Add(duration)
 		spID, password, err := c.provider.CreateServicePrincipal(ctx, app.AppID, now, endDate)
-
 		// Propagation delays within Azure can cause transient errors when creating
 		// a service principal immediately after creating an application. Different
 		// tenants and APIs emit slightly different error messages, so match on a
 		// broader set of substrings rather than a single exact string.
 		if err != nil {
 			errStr := strings.ToLower(err.Error())
-			retryable :=
-				strings.Contains(errStr, "local tenant") ||
-					strings.Contains(errStr, errInvalidApplicationObject) ||
-					strings.Contains(errStr, "authorization_requestdenied") ||
-					strings.Contains(errStr, "propagation") ||
-					strings.Contains(errStr, "please try again") ||
-					strings.Contains(errStr, "could not find") ||
-					strings.Contains(errStr, "not found")
+			retryable := strings.Contains(errStr, "local tenant") ||
+				strings.Contains(errStr, errInvalidApplicationObject) ||
+				strings.Contains(errStr, "authorization_requestdenied") ||
+				strings.Contains(errStr, "propagation") ||
+				strings.Contains(errStr, "please try again") ||
+				strings.Contains(errStr, "could not find") ||
+				strings.Contains(errStr, "not found") ||
+				strings.Contains(errStr, "does not exist") ||
+				strings.Contains(errStr, "reference-property")
 
 			if retryable {
 				return nil, false, nil
@@ -121,7 +122,6 @@ func (c *client) createSP(
 
 		return result, true, err
 	})
-
 	if err != nil {
 		return "", "", time.Time{}, fmt.Errorf("error creating service principal: %w", err)
 	}
@@ -199,12 +199,13 @@ func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRol
 					Properties: &armauthorization.RoleAssignmentProperties{
 						RoleDefinitionID: &role.RoleID,
 						PrincipalID:      &spID,
+						PrincipalType:    to.Ptr(armauthorization.PrincipalTypeServicePrincipal),
 					},
 				})
 
 			// Propagation delays within Azure can cause this error occasionally, so don't quit on it.
 			if err != nil && strings.Contains(err.Error(), "PrincipalNotFound") {
-				return nil, false, nil
+				return nil, false, err
 			}
 			// check if ra is an empty response
 			// if so, return empty string
@@ -213,7 +214,6 @@ func (c *client) assignRoles(ctx context.Context, spID string, roles []*AzureRol
 			}
 			return *ra.ID, true, err
 		})
-
 		if err != nil {
 			return nil, fmt.Errorf("error while assigning roles: %w", err)
 		}
@@ -259,7 +259,6 @@ func (c *client) addGroupMemberships(ctx context.Context, spID string, groups []
 
 			return nil, true, err
 		})
-
 		if err != nil {
 			return fmt.Errorf("error while adding group membership: %w", err)
 		}
@@ -295,7 +294,6 @@ func groupObjectIDs(groups []*AzureGroup) []string {
 	groupIDs := make([]string, 0, len(groups))
 	for _, group := range groups {
 		groupIDs = append(groupIDs, group.ObjectID)
-
 	}
 	return groupIDs
 }
@@ -420,7 +418,7 @@ func graphURIFromName(name string) (string, error) {
 //   - 80 seconds elapses. Vault's default request timeout is 90s; we want to expire before then.
 //
 // Delays are random but will average 5 seconds.
-func retry(ctx context.Context, f func() (interface{}, bool, error)) (interface{}, error) {
+func retry(ctx context.Context, f func() (any, bool, error)) (result any, err error) {
 	delayTimer := time.NewTimer(0)
 	if _, hasTimeout := ctx.Deadline(); !hasTimeout {
 		var cancel func()
@@ -429,24 +427,18 @@ func retry(ctx context.Context, f func() (interface{}, bool, error)) (interface{
 	}
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	var lastErr error
+	var done bool
 	for {
 		select {
 		case <-delayTimer.C:
-			result, done, err := f()
-			if done {
+			if result, done, err = f(); done {
 				return result, err
 			}
-			lastErr = err
 
 			delay := time.Duration(2+rng.Intn(6)) * time.Second
 			delayTimer.Reset(delay)
 		case <-ctx.Done():
-			err := lastErr
-			if err == nil {
-				err = ctx.Err()
-			}
-			return nil, fmt.Errorf("retry failed: %w", err)
+			return nil, fmt.Errorf("retry failed: %w", errors.Join(err, ctx.Err()))
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRetry(t *testing.T) {
@@ -94,12 +95,32 @@ func TestRetry(t *testing.T) {
 		elapsed := time.Now().Sub(start)
 		assertDuration(t, elapsed, 1*time.Second, 250*time.Millisecond)
 
-		if err == nil {
-			t.Fatalf("expected err: got nil")
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("Error preservation on timeout", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
 		}
-		underlyingErr := errors.Unwrap(err)
-		if underlyingErr != context.Canceled {
-			t.Fatalf("expected %s, got: %v", context.Canceled, err)
+		t.Parallel()
+
+		timeout := 5 * time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		expectedErr := errors.New("Resource does not exist or one of its queried reference-property objects are not present")
+		_, err := retry(ctx, func() (interface{}, bool, error) {
+			// Simulate retryable error that never succeeds
+			return nil, false, expectedErr
+		})
+
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		// Verify the original error is preserved in the retry failure message
+		if !strings.Contains(err.Error(), expectedErr.Error()) {
+			t.Fatalf("expected error to contain original message %q, got: %v", expectedErr.Error(), err)
 		}
 	})
 }
@@ -133,7 +154,6 @@ func TestSPCreate_RetryLogic(t *testing.T) {
 		Path:      "creds/" + roleName,
 		Storage:   s,
 	})
-
 	// The retry logic should hide the transient failures
 	if err != nil {
 		t.Fatalf("Expected retry logic to recover but got error: %v", err)
@@ -145,6 +165,240 @@ func TestSPCreate_RetryLogic(t *testing.T) {
 	// Validate retry behavior: 3 failures + 1 success = 4 calls
 	if mp.servicePrincipalCalls != 4 {
 		t.Fatalf("Expected 4 calls (3 failures + 1 success), got %d", mp.servicePrincipalCalls)
+	}
+}
+
+// TestSPCreate_AzurePropagationErrors verifies that the retry logic correctly identifies
+// and retries on Azure propagation delay error messages, including the "does not exist"
+// and "reference-property" patterns reported in customer support tickets.
+func TestSPCreate_AzurePropagationErrors(t *testing.T) {
+	t.Parallel()
+
+	// Test cases covering various Azure propagation error messages
+	testCases := []struct {
+		name         string
+		errorMessage string
+		shouldRetry  bool
+	}{
+		{
+			name:         "reference-property error",
+			errorMessage: "Resource '0c760b20-e7a6-4611-950c-68ff06816696' does not exist or one of its queried reference-property objects are not present",
+			shouldRetry:  true,
+		},
+		{
+			name:         "does not exist error",
+			errorMessage: "Application with identifier 'abc123' does not exist in the directory",
+			shouldRetry:  true,
+		},
+		{
+			name:         "local tenant error",
+			errorMessage: "When using this permission, the backing application of the service principal being created must be in the local tenant",
+			shouldRetry:  true,
+		},
+		{
+			name:         "not found error",
+			errorMessage: "Application not found",
+			shouldRetry:  true,
+		},
+		{
+			name:         "propagation error",
+			errorMessage: "Changes are still propagating, please try again",
+			shouldRetry:  true,
+		},
+		{
+			name:         "non-retryable error",
+			errorMessage: "Insufficient privileges to complete the operation",
+			shouldRetry:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, s := getTestBackendMocked(t, true)
+			mp := newMockProvider().(*mockProvider)
+
+			// Configure mock to fail with specific error message
+			mp.servicePrincipalErrorMessage = tc.errorMessage
+			if tc.shouldRetry {
+				mp.servicePrincipalFailureCount = 2 // Fail twice, then succeed
+			} else {
+				mp.servicePrincipalFailureCount = 100 // Always fail for non-retryable
+			}
+			mp.servicePrincipalCalls = 0
+
+			b.getProvider = func(ctx context.Context, lg hclog.Logger, sys logical.SystemView, cs *clientSettings) (AzureProvider, error) {
+				return mp, nil
+			}
+
+			roleName := generateUUID()
+			testRoleCreate(t, b, s, roleName, testRole)
+
+			// Set a shorter timeout for non-retryable errors
+			ctx := context.Background()
+			if !tc.shouldRetry {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+				defer cancel()
+			}
+
+			resp, err := b.HandleRequest(ctx, &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      "creds/" + roleName,
+				Storage:   s,
+			})
+
+			if tc.shouldRetry {
+				// Should succeed after retries
+				if err != nil {
+					t.Fatalf("Expected retry logic to recover from %q, but got error: %v", tc.errorMessage, err)
+				}
+				if resp.IsError() {
+					t.Fatalf("Expected success after retries, got response error: %v", resp.Error())
+				}
+				// Verify it actually retried
+				if mp.servicePrincipalCalls <= 1 {
+					t.Fatalf("Expected multiple calls due to retries, got %d", mp.servicePrincipalCalls)
+				}
+			} else {
+				// Should fail without retrying extensively
+				if err == nil && !resp.IsError() {
+					t.Fatalf("Expected non-retryable error %q to fail", tc.errorMessage)
+				}
+				// Verify the original error message is preserved
+				errMsg := ""
+				if err != nil {
+					errMsg = err.Error()
+				} else if resp.IsError() {
+					errMsg = resp.Error().Error()
+				}
+				if !strings.Contains(errMsg, tc.errorMessage) {
+					t.Fatalf("Expected error to contain %q, got: %v", tc.errorMessage, errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestRoleAssignment_RetryLogic verifies that role assignment retries on PrincipalNotFound
+// errors and preserves error messages when retries are exhausted.
+func TestRoleAssignment_RetryLogic(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		failureCount  int
+		errorMessage  string
+		shouldSucceed bool
+		expectRetries bool
+	}{
+		{
+			name:          "success after retries on PrincipalNotFound",
+			failureCount:  2,
+			errorMessage:  "PrincipalNotFound",
+			shouldSucceed: true,
+			expectRetries: true,
+		},
+		{
+			name:          "error message preserved on timeout",
+			failureCount:  100, // Will exhaust retries
+			errorMessage:  "PrincipalNotFound - service principal not replicated",
+			shouldSucceed: false,
+			expectRetries: true,
+		},
+		{
+			name:          "non-retryable error fails immediately",
+			failureCount:  100,
+			errorMessage:  "Insufficient privileges",
+			shouldSucceed: false,
+			expectRetries: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, s := getTestBackendMocked(t, true)
+			mp := newMockProvider().(*mockProvider)
+
+			// Configure role assignment failures
+			mp.roleAssignmentErrorMessage = tc.errorMessage
+			mp.roleAssignmentFailureCount = tc.failureCount
+			mp.roleAssignmentCalls = 0
+
+			b.getProvider = func(ctx context.Context, lg hclog.Logger, sys logical.SystemView, cs *clientSettings) (AzureProvider, error) {
+				return mp, nil
+			}
+
+			// Create a role with Azure role assignments
+			roleName := generateUUID()
+			roleData := map[string]interface{}{
+				"azure_roles": encodeJSON([]AzureRole{
+					{
+						RoleName: "Contributor",
+						RoleID:   "/subscriptions/FAKE_SUB_ID/providers/Microsoft.Authorization/roleDefinitions/FAKE_ROLE-Contributor",
+						Scope:    "/subscriptions/test-subscription",
+					},
+				}),
+			}
+			testRoleCreate(t, b, s, roleName, roleData)
+
+			// Set timeout for non-retryable errors
+			ctx := context.Background()
+			if !tc.expectRetries {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+				defer cancel()
+			}
+
+			// Request credentials - this triggers role assignment
+			resp, err := b.HandleRequest(ctx, &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      "creds/" + roleName,
+				Storage:   s,
+			})
+
+			if tc.shouldSucceed {
+				if err != nil {
+					t.Fatalf("Expected success after retries, got error: %v", err)
+				}
+				if resp.IsError() {
+					t.Fatalf("Expected success, got response error: %v", resp.Error())
+				}
+				// Verify retries occurred
+				if mp.roleAssignmentCalls <= 1 {
+					t.Fatalf("Expected multiple role assignment calls due to retries, got %d", mp.roleAssignmentCalls)
+				}
+			} else {
+				// Should fail
+				if err == nil && !resp.IsError() {
+					t.Fatalf("Expected failure for error %q", tc.errorMessage)
+				}
+
+				// Verify error message is preserved
+				errMsg := ""
+				if err != nil {
+					errMsg = err.Error()
+				} else if resp.IsError() {
+					errMsg = resp.Error().Error()
+				}
+
+				if !strings.Contains(errMsg, tc.errorMessage) {
+					t.Fatalf("Expected error to contain %q, got: %v", tc.errorMessage, errMsg)
+				}
+
+				// Verify retry behavior
+				if tc.expectRetries && mp.roleAssignmentCalls <= 1 {
+					t.Fatalf("Expected multiple retry attempts, got %d calls", mp.roleAssignmentCalls)
+				} else if !tc.expectRetries && mp.roleAssignmentCalls > 2 {
+					t.Fatalf("Expected minimal retries for non-retryable error, got %d calls", mp.roleAssignmentCalls)
+				}
+			}
+		})
 	}
 }
 

--- a/provider_mock_test.go
+++ b/provider_mock_test.go
@@ -30,6 +30,10 @@ type mockProvider struct {
 	failNextCreateServicePrincipal bool
 	servicePrincipalFailureCount   int
 	servicePrincipalCalls          int
+	servicePrincipalErrorMessage   string
+	roleAssignmentFailureCount     int
+	roleAssignmentCalls            int
+	roleAssignmentErrorMessage     string
 	unassignRolesFailureParams     failureParams
 	ctxTimeout                     time.Duration
 	lock                           sync.Mutex
@@ -119,9 +123,11 @@ func (m *mockProvider) CreateServicePrincipal(_ context.Context, _ string, _ tim
 
 	// Fail first N attempts to simulate Azure graph propagation delay
 	if m.servicePrincipalCalls <= m.servicePrincipalFailureCount {
-		return "", "", fmt.Errorf(
-			"When using this permission, the backing application of the service principal being created must be in the local tenant",
-		)
+		errMsg := m.servicePrincipalErrorMessage
+		if errMsg == "" {
+			errMsg = "When using this permission, the backing application of the service principal being created must be in the local tenant"
+		}
+		return "", "", errors.New(errMsg)
 	}
 
 	// Success after failures
@@ -233,6 +239,20 @@ func (m *mockProvider) passwordExists(s string) bool {
 }
 
 func (m *mockProvider) CreateRoleAssignment(_ context.Context, scope string, name string, params armauthorization.RoleAssignmentCreateParameters) (armauthorization.RoleAssignmentsClientCreateResponse, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.roleAssignmentCalls++
+
+	// Fail first N attempts to simulate Azure propagation delay
+	if m.roleAssignmentCalls <= m.roleAssignmentFailureCount {
+		errMsg := m.roleAssignmentErrorMessage
+		if errMsg == "" {
+			errMsg = "PrincipalNotFound"
+		}
+		return armauthorization.RoleAssignmentsClientCreateResponse{}, errors.New(errMsg)
+	}
+
 	return armauthorization.RoleAssignmentsClientCreateResponse{
 		RoleAssignment: armauthorization.RoleAssignment{
 			Properties: &armauthorization.RoleAssignmentProperties{
@@ -295,7 +315,6 @@ func (m *mockProvider) ListGroups(_ context.Context, filter string) ([]api.Group
 	if len(match) > 0 {
 		name := match[0][1]
 		if name == "multiple" {
-
 			return []api.Group{
 				{
 					ID:          fmt.Sprintf("00000000-1111-2222-3333-444444444444FAKE_GROUP-%s-1", name),
@@ -317,5 +336,4 @@ func (m *mockProvider) ListGroups(_ context.Context, filter string) ([]api.Group
 	}
 
 	return []api.Group{}, nil
-
 }


### PR DESCRIPTION
# Overview
This PR updates retry logic and error handling.

- Retry on error `"Resource '...' does not exist or one of its queried reference-property objects are not present"`
- Set `principalType: "ServicePrincipal"` when creating role assignments
  - reduces the likelihood of propagation errors. This follows Microsoft's best practices for working with new service principals.
  - Reference: [Azure RBAC Role Assignments - New Service Principal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-rest#new-service-principal)
- Maintain error messages for retry expirations
- Add tests cases for these changes