### PR TITLE
Removes usage of deprecated API

### DIFF
--- a/path_roles.go
+++ b/path_roles.go
@@ -122,11 +122,25 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 					Default:     false,
 				},
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ReadOperation:   b.pathRoleRead,
-				logical.CreateOperation: b.pathRoleUpdate,
-				logical.UpdateOperation: b.pathRoleUpdate,
-				logical.DeleteOperation: b.pathRoleDelete,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ReadOperation: &framework.PathOperation{
+					Callback: b.pathRoleRead,
+				},
+				logical.CreateOperation: &framework.PathOperation{
+					Callback:                    b.pathRoleUpdate,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
+				},
+				logical.UpdateOperation: &framework.PathOperation{
+					Callback:                    b.pathRoleUpdate,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
+				},
+				logical.DeleteOperation: &framework.PathOperation{
+					Callback:                    b.pathRoleDelete,
+					ForwardPerformanceSecondary: true,
+					ForwardPerformanceStandby:   true,
+				},
 			},
 			HelpSynopsis:    roleHelpSyn,
 			HelpDescription: roleHelpDesc,
@@ -138,8 +152,10 @@ func pathsRole(b *azureSecretBackend) []*framework.Path {
 				OperationPrefix: operationPrefixAzure,
 				OperationSuffix: "roles",
 			},
-			Callbacks: map[logical.Operation]framework.OperationFunc{
-				logical.ListOperation: b.pathRoleList,
+			Operations: map[logical.Operation]framework.OperationHandler{
+				logical.ListOperation: &framework.PathOperation{
+					Callback: b.pathRoleList,
+				},
 			},
 			HelpSynopsis:    roleListHelpSyn,
 			HelpDescription: roleListHelpDesc,


### PR DESCRIPTION
# Overview

Completes the change to newer Vault Plugin SDK attributes (`Callbacks` -> `Operations`). No change to overall API and strictly fixes a bug (see below).

# Related Issues/Pull Requests

- Azure secrets engine fails to update underlying data when sent to performance standby node

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.


  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
