### PR TITLE
Backport to prevent vulnerability

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -46,6 +46,15 @@ func (d testSystemViewEnt) DeregisterRotationJob(_ context.Context, _ *rotation.
 	return nil
 }
 
+func newTestSystemView(t *testing.T) logical.SystemView {
+	t.Helper()
+
+	sysView := &testSystemViewEnt{}
+	sysView.DefaultLeaseTTLVal = defaultLeaseTTLHr
+	sysView.MaxLeaseTTLVal = maxLeaseTTLHr
+	return sysView
+}
+
 func getTestBackendMocked(t *testing.T, initConfig bool) (*azureSecretBackend, logical.Storage) {
 	b := backend()
 	sysView := testSystemViewEnt{}
@@ -84,6 +93,55 @@ func getTestBackendMocked(t *testing.T, initConfig bool) (*azureSecretBackend, l
 	}
 
 	return b, config.StorageView
+}
+
+func getTestBackendWithStorage(t *testing.T, initConfig bool, storage logical.Storage, withEvents bool) (*azureSecretBackend, logical.Storage, *logical.MockEventSender, *mockProvider) {
+	t.Helper()
+
+	if storage == nil {
+		storage = &logical.InmemStorage{}
+	}
+
+	var eventSender *logical.MockEventSender
+	config := &logical.BackendConfig{
+		Logger:      logging.NewVaultLogger(log.Trace),
+		System:      newTestSystemView(t),
+		StorageView: storage,
+		Config:      make(map[string]string),
+	}
+	if withEvents {
+		eventSender = logical.NewMockEventSender()
+		config.EventsSender = eventSender
+	}
+
+	b, err := Factory(context.Background(), config)
+	if err != nil {
+		t.Fatalf("unable to create backend: %v", err)
+	}
+
+	retBackend := b.(*azureSecretBackend)
+	retBackend.settings = new(clientSettings)
+	mockProvider := newMockProvider().(*mockProvider)
+	retBackend.getProvider = func(context.Context, hclog.Logger, logical.SystemView, *clientSettings) (AzureProvider, error) {
+		return mockProvider, nil
+	}
+
+	if initConfig {
+		cfg := map[string]interface{}{
+			"subscription_id":  generateUUID(),
+			"tenant_id":        generateUUID(),
+			"client_id":        testClientID,
+			"client_secret":    testClientSecret,
+			"environment":      "AZURECHINACLOUD",
+			"ttl":              defaultTestTTL,
+			"max_ttl":          defaultTestMaxTTL,
+			"explicit_max_ttl": defaultTestExplicitMaxTTL,
+		}
+
+		testConfigCreate(t, retBackend, config.StorageView, cfg, false)
+	}
+
+	return retBackend, config.StorageView, eventSender, mockProvider
 }
 
 func getTestBackend(t *testing.T) (*azureSecretBackend, logical.Storage) {

--- a/path_roles.go
+++ b/path_roles.go
@@ -23,6 +23,8 @@ const (
 	rolesStoragePath = "roles"
 
 	credentialTypeSP = 0
+
+	msgTargetRootCredential = "cannot target the root credential of the plugin"
 )
 
 // roleEntry is a Vault role construct that maps to Azure roles or Applications
@@ -274,6 +276,10 @@ func (b *azureSecretBackend) pathRoleUpdate(ctx context.Context, req *logical.Re
 			return nil, fmt.Errorf("error loading Application: %w", err)
 		}
 		role.ApplicationID = app.AppID
+
+		if config.ClientID != "" && app.AppID == config.ClientID {
+			return nil, logical.CodedError(400, msgTargetRootCredential)
+		}
 
 		if role.PermanentlyDelete {
 			return logical.ErrorResponse("permanently_delete must be false if application_object_id is provided"), nil

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoleCreate(t *testing.T) {
@@ -572,6 +573,107 @@ func TestRoleCreateBad(t *testing.T) {
 	if !strings.Contains(resp.Error().Error(), msg) {
 		t.Fatalf("expected to find: %s, got: %s", msg, resp.Error().Error())
 	}
+}
+
+// TestRoleCreate_SelfTargetBlocked verifies that creating a role targeting
+// Vault's own Azure application is rejected.
+func TestRoleCreate_SelfTargetBlocked(t *testing.T) {
+	b, s, _, mp := getTestBackendWithStorage(t, true, nil, false)
+
+	// Seed the mock provider so that the application object ID resolves
+	// to an AppID equal to the configured client_id (testClientID).
+	vaultAppObjectID := "root credential"
+	mp.lock.Lock()
+	mp.applications[vaultAppObjectID] = testClientID
+	mp.lock.Unlock()
+
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "roles/foo",
+		Data: map[string]any{
+			"application_object_id": vaultAppObjectID,
+		},
+		Storage: s,
+	})
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, msgTargetRootCredential)
+}
+
+// TestRoleUpdate_SelfTargetBlocked verifies that updating a role to target
+// Vault's own Azure application is rejected.
+func TestRoleUpdate_SelfTargetBlocked(t *testing.T) {
+	b, s, _, mp := getTestBackendWithStorage(t, true, nil, false)
+
+	// First create a legitimate role with a different app
+	legitimateAppObjID := "legitimate-app-object-id"
+	mp.lock.Lock()
+	mp.applications[legitimateAppObjID] = "some-other-client-id"
+	mp.lock.Unlock()
+
+	role := map[string]interface{}{
+		"application_object_id": legitimateAppObjID,
+	}
+	testRoleCreate(t, b, s, "update_target_role", role)
+
+	// Now seed Vault's own app and attempt to update the role to target it
+	vaultAppObjectID := "root credential"
+	mp.lock.Lock()
+	mp.applications[vaultAppObjectID] = testClientID
+	mp.lock.Unlock()
+
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "roles/update_target_role",
+		Data: map[string]interface{}{
+			"application_object_id": vaultAppObjectID,
+		},
+		Storage: s,
+	})
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, msgTargetRootCredential)
+}
+
+// TestRoleCreate_DifferentAppAllowed verifies that targeting a non-Vault
+// application still succeeds.
+func TestRoleCreate_DifferentAppAllowed(t *testing.T) {
+	b, s, _, mp := getTestBackendWithStorage(t, true, nil, false)
+
+	otherAppObjID := "other-app-object-id"
+	mp.lock.Lock()
+	mp.applications[otherAppObjID] = "completely-different-client-id"
+	mp.lock.Unlock()
+
+	role := map[string]interface{}{
+		"application_object_id": otherAppObjID,
+	}
+	testRoleCreate(t, b, s, "different_app_role", role)
+}
+
+// TestRoleCreate_EmptyClientIDSkipsGuard verifies that when config has no
+// client_id (e.g. WIF-only setups), the self-target guard is safely skipped.
+func TestRoleCreate_EmptyClientIDSkipsGuard(t *testing.T) {
+	b, s, _, mp := getTestBackendWithStorage(t, false, nil, false)
+
+	// Configure with empty client_id
+	cfg := map[string]interface{}{
+		"subscription_id": generateUUID(),
+		"tenant_id":       generateUUID(),
+		"client_id":       "",
+		"client_secret":   "",
+	}
+	testConfigCreate(t, b, s, cfg, false)
+
+	someAppObjID := "some-app-object-id"
+	mp.lock.Lock()
+	mp.applications[someAppObjID] = "any-app-id"
+	mp.lock.Unlock()
+
+	role := map[string]interface{}{
+		"application_object_id": someAppObjID,
+	}
+	testRoleCreate(t, b, s, "empty_client_id_role", role)
 }
 
 // TestRolesCreate_applicationObjectID tests that a role


### PR DESCRIPTION
# Overview
This PR is meant to patch a potential vulnerability fix where a user can create an application using Vault's credentials, rotate its secret, and then have access to Vault.

PRs being backported:
1. https://github.com/hashicorp/vault-plugin-secrets-azure-enterprise/pull/69
2. https://github.com/hashicorp/vault-plugin-secrets-azure-enterprise/pull/76